### PR TITLE
Set up daily postgres metadata pipeline with dbt

### DIFF
--- a/dbt_projects/motherduck/extract_postgres.sql
+++ b/dbt_projects/motherduck/extract_postgres.sql
@@ -1,0 +1,122 @@
+-- DuckDB -> MotherDuck extraction script
+-- Purpose: Attach to Postgres and MotherDuck, mirror core tables, and extract
+--          metadata/statistics into MotherDuck tables for downstream dbt models.
+-- Run cadence: Daily (idempotent). Uses CREATE OR REPLACE to refresh snapshots.
+
+-- 1) Extensions
+INSTALL motherduck;
+LOAD motherduck;
+INSTALL postgres;
+LOAD postgres;
+
+-- 2) Optional performance tuning
+SET threads TO 8;
+
+-- 3) Authentication/attachments
+-- NOTE: Replace placeholders with your actual values or set via environment.
+-- MotherDuck (requires MD token or configured local/CI env)
+-- SET motherduck_token='YOUR_MOTHERDUCK_TOKEN'; -- uncomment if needed
+ATTACH 'md:your_motherduck_database' AS md; -- e.g. md:org/db_name
+
+-- Postgres (read-only recommended for safety)
+-- Example: postgresql://user:pass@host:5432/dbname
+ATTACH 'postgresql://USERNAME:PASSWORD@HOST:5432/DATABASE' AS pg (READ_ONLY);
+
+-- 4) Create schemas in MotherDuck if not present
+CREATE SCHEMA IF NOT EXISTS md.raw;
+CREATE SCHEMA IF NOT EXISTS md.meta;
+
+-- 5) Snapshot/mirror core operational tables from Postgres into MotherDuck raw
+--    We use CREATE OR REPLACE for a simple, robust daily refresh.
+CREATE OR REPLACE TABLE md.raw.task_runs AS
+SELECT *
+FROM pg.public.task_runs;
+
+CREATE OR REPLACE TABLE md.raw.pipeline_runs AS
+SELECT *
+FROM pg.public.pipeline_runs;
+
+-- 6) Extract light metadata and statistics directly from Postgres
+--    a) Row counts per relevant table
+CREATE OR REPLACE TABLE md.meta.table_row_counts AS
+SELECT 'task_runs' AS table_name, COUNT(*)::UBIGINT AS row_count, now() AS extracted_at
+FROM pg.public.task_runs
+UNION ALL
+SELECT 'pipeline_runs' AS table_name, COUNT(*)::UBIGINT AS row_count, now() AS extracted_at
+FROM pg.public.pipeline_runs;
+
+--    b) Column-level metadata for the two tables
+CREATE OR REPLACE TABLE md.meta.columns_metadata AS
+SELECT
+  c.table_schema,
+  c.table_name,
+  c.column_name,
+  c.ordinal_position,
+  c.data_type,
+  c.is_nullable,
+  now() AS extracted_at
+FROM pg.information_schema.columns c
+WHERE c.table_schema = 'public'
+  AND c.table_name IN ('task_runs','pipeline_runs')
+ORDER BY c.table_name, c.ordinal_position;
+
+--    c) Status distributions (daily) for each table, computed against Postgres
+--       These do not assume foreign keys; they only rely on common columns.
+--       If columns are missing, adjust as needed.
+CREATE OR REPLACE TABLE md.meta.task_run_status_daily AS
+SELECT
+  CAST(date_trunc('day', COALESCE(t.started_at, t.completed_at, t.updated_at)) AS DATE) AS run_date,
+  t.status,
+  COUNT(*)::UBIGINT AS run_count,
+  now() AS extracted_at
+FROM pg.public.task_runs t
+GROUP BY 1,2
+ORDER BY 1,2;
+
+CREATE OR REPLACE TABLE md.meta.pipeline_run_status_daily AS
+SELECT
+  CAST(date_trunc('day', COALESCE(p.started_at, p.completed_at, p.updated_at)) AS DATE) AS run_date,
+  p.status,
+  COUNT(*)::UBIGINT AS run_count,
+  now() AS extracted_at
+FROM pg.public.pipeline_runs p
+GROUP BY 1,2
+ORDER BY 1,2;
+
+--    d) Duration statistics (seconds) computed directly from Postgres
+CREATE OR REPLACE TABLE md.meta.pipeline_run_duration_stats AS
+WITH base AS (
+  SELECT
+    CAST(date_trunc('day', COALESCE(p.started_at, p.completed_at, p.updated_at)) AS DATE) AS run_date,
+    datediff('second', p.started_at, p.completed_at) AS duration_seconds
+  FROM pg.public.pipeline_runs p
+  WHERE p.started_at IS NOT NULL AND p.completed_at IS NOT NULL
+)
+SELECT
+  run_date,
+  COUNT(*)::UBIGINT AS num_runs,
+  AVG(duration_seconds)::DOUBLE AS avg_duration_seconds,
+  MIN(duration_seconds)::BIGINT AS min_duration_seconds,
+  MAX(duration_seconds)::BIGINT AS max_duration_seconds,
+  approx_quantile(duration_seconds, 0.50) AS p50_duration_seconds,
+  approx_quantile(duration_seconds, 0.90) AS p90_duration_seconds,
+  now() AS extracted_at
+FROM base
+GROUP BY 1
+ORDER BY 1;
+
+-- 7) Optional ingestion run log (append-only)
+CREATE TABLE IF NOT EXISTS md.meta.ingestion_runs (
+  run_id            UUID DEFAULT uuid(),
+  run_ts            TIMESTAMP DEFAULT now(),
+  source_name       TEXT,
+  details           JSON
+);
+
+INSERT INTO md.meta.ingestion_runs (source_name, details)
+VALUES
+  ('postgres/public.task_runs', '{"action":"snapshot","tables":["task_runs","pipeline_runs"]}'),
+  ('postgres/public.pipeline_runs', '{"action":"snapshot","tables":["task_runs","pipeline_runs"]}');
+
+-- End of script
+

--- a/dbt_projects/motherduck/models/motherduck/aggregated/fct_daily_pipeline_kpis.sql
+++ b/dbt_projects/motherduck/models/motherduck/aggregated/fct_daily_pipeline_kpis.sql
@@ -1,0 +1,46 @@
+-- Daily pipeline run KPIs: counts, success rate, and duration metrics
+WITH base AS (
+  SELECT
+    run_date,
+    status,
+    duration_seconds
+  FROM {{ ref('stg_pipeline_runs') }}
+),
+by_status AS (
+  SELECT
+    run_date,
+    SUM(CASE WHEN lower(status) IN ('success','succeeded','completed') THEN 1 ELSE 0 END) AS num_success,
+    SUM(CASE WHEN lower(status) IN ('failed','error') THEN 1 ELSE 0 END) AS num_failed,
+    COUNT(*) AS num_total
+  FROM base
+  GROUP BY 1
+),
+duration_stats AS (
+  SELECT
+    run_date,
+    COUNT(*)::UBIGINT AS num_with_duration,
+    AVG(duration_seconds)::DOUBLE AS avg_duration_seconds,
+    MIN(duration_seconds)::BIGINT AS min_duration_seconds,
+    MAX(duration_seconds)::BIGINT AS max_duration_seconds,
+    approx_quantile(duration_seconds, 0.50) AS p50_duration_seconds,
+    approx_quantile(duration_seconds, 0.90) AS p90_duration_seconds
+  FROM base
+  WHERE duration_seconds IS NOT NULL AND duration_seconds >= 0
+  GROUP BY 1
+)
+SELECT
+  b.run_date,
+  b.num_total,
+  b.num_success,
+  b.num_failed,
+  CASE WHEN b.num_total > 0 THEN b.num_success::DOUBLE / b.num_total ELSE NULL END AS success_rate,
+  d.num_with_duration,
+  d.avg_duration_seconds,
+  d.min_duration_seconds,
+  d.max_duration_seconds,
+  d.p50_duration_seconds,
+  d.p90_duration_seconds
+FROM by_status b
+LEFT JOIN duration_stats d USING (run_date)
+ORDER BY 1;
+

--- a/dbt_projects/motherduck/models/motherduck/aggregated/fct_daily_table_row_counts.sql
+++ b/dbt_projects/motherduck/models/motherduck/aggregated/fct_daily_table_row_counts.sql
@@ -1,0 +1,9 @@
+-- Daily snapshot of table row counts for mirrored raw tables
+SELECT
+  CAST(date_trunc('day', extracted_at) AS DATE) AS run_date,
+  table_name,
+  MAX(row_count) AS row_count
+FROM {{ source('md_meta', 'table_row_counts') }}
+GROUP BY 1,2
+ORDER BY 1,2;
+

--- a/dbt_projects/motherduck/models/motherduck/aggregated/fct_daily_task_run_statuses.sql
+++ b/dbt_projects/motherduck/models/motherduck/aggregated/fct_daily_task_run_statuses.sql
@@ -1,0 +1,12 @@
+-- Daily task run counts by status
+WITH base AS (
+  SELECT run_date, status FROM {{ ref('stg_task_runs') }}
+)
+SELECT
+  run_date,
+  status,
+  COUNT(*)::UBIGINT AS run_count
+FROM base
+GROUP BY 1,2
+ORDER BY 1,2;
+

--- a/dbt_projects/motherduck/models/motherduck/production/kpi_dashboard.sql
+++ b/dbt_projects/motherduck/models/motherduck/production/kpi_dashboard.sql
@@ -1,0 +1,28 @@
+-- Simple production-facing KPI table joining key daily facts
+WITH a AS (
+  SELECT * FROM {{ ref('fct_daily_pipeline_kpis') }}
+),
+b AS (
+  SELECT * FROM {{ ref('fct_daily_task_run_statuses') }}
+),
+c AS (
+  SELECT * FROM {{ ref('fct_daily_table_row_counts') }}
+)
+SELECT
+  a.run_date,
+  a.num_total AS pipeline_runs_total,
+  a.num_success AS pipeline_runs_success,
+  a.num_failed AS pipeline_runs_failed,
+  a.success_rate,
+  a.avg_duration_seconds,
+  a.p50_duration_seconds,
+  a.p90_duration_seconds,
+  SUM(CASE WHEN b.status IS NOT NULL THEN b.run_count ELSE 0 END) AS task_runs_total,
+  MAX(CASE WHEN c.table_name = 'task_runs' THEN c.row_count END) AS task_runs_rows,
+  MAX(CASE WHEN c.table_name = 'pipeline_runs' THEN c.row_count END) AS pipeline_runs_rows
+FROM a
+LEFT JOIN b USING (run_date)
+LEFT JOIN c USING (run_date)
+GROUP BY 1,2,3,4,5,6,7,8
+ORDER BY 1;
+

--- a/dbt_projects/motherduck/models/motherduck/staging/stg_pipeline_runs.sql
+++ b/dbt_projects/motherduck/models/motherduck/staging/stg_pipeline_runs.sql
@@ -1,0 +1,29 @@
+-- Staging model for pipeline_runs
+-- Assumes columns: id, status, started_at, completed_at, updated_at, created_at
+WITH source AS (
+  SELECT * FROM {{ source('md_raw', 'pipeline_runs') }}
+),
+typed AS (
+  SELECT
+    CAST(id AS VARCHAR)                           AS pipeline_run_id,
+    CAST(status AS VARCHAR)                       AS status,
+    TRY_CAST(started_at AS TIMESTAMP)             AS started_at,
+    TRY_CAST(completed_at AS TIMESTAMP)           AS completed_at,
+    TRY_CAST(updated_at AS TIMESTAMP)             AS updated_at,
+    TRY_CAST(created_at AS TIMESTAMP)             AS created_at
+  FROM source
+),
+final AS (
+  SELECT
+    pipeline_run_id,
+    status,
+    started_at,
+    completed_at,
+    updated_at,
+    created_at,
+    datediff('second', started_at, completed_at)  AS duration_seconds,
+    CAST(date_trunc('day', COALESCE(started_at, completed_at, updated_at, created_at)) AS DATE) AS run_date
+  FROM typed
+)
+SELECT * FROM final;
+

--- a/dbt_projects/motherduck/models/motherduck/staging/stg_task_runs.sql
+++ b/dbt_projects/motherduck/models/motherduck/staging/stg_task_runs.sql
@@ -1,0 +1,31 @@
+-- Staging model for task_runs
+-- Assumes columns: id, pipeline_run_id, status, started_at, completed_at, updated_at, created_at
+WITH source AS (
+  SELECT * FROM {{ source('md_raw', 'task_runs') }}
+),
+typed AS (
+  SELECT
+    CAST(id AS VARCHAR)                           AS task_run_id,
+    CAST(pipeline_run_id AS VARCHAR)              AS pipeline_run_id,
+    CAST(status AS VARCHAR)                       AS status,
+    TRY_CAST(started_at AS TIMESTAMP)             AS started_at,
+    TRY_CAST(completed_at AS TIMESTAMP)           AS completed_at,
+    TRY_CAST(updated_at AS TIMESTAMP)             AS updated_at,
+    TRY_CAST(created_at AS TIMESTAMP)             AS created_at
+  FROM source
+),
+final AS (
+  SELECT
+    task_run_id,
+    pipeline_run_id,
+    status,
+    started_at,
+    completed_at,
+    updated_at,
+    created_at,
+    datediff('second', started_at, completed_at)  AS duration_seconds,
+    CAST(date_trunc('day', COALESCE(started_at, completed_at, updated_at, created_at)) AS DATE) AS run_date
+  FROM typed
+)
+SELECT * FROM final;
+

--- a/dbt_projects/motherduck/models/schema.yml
+++ b/dbt_projects/motherduck/models/schema.yml
@@ -1,0 +1,59 @@
+version: 2
+
+models:
+  - name: stg_task_runs
+    description: Cleaned and typed staging table for task runs.
+    columns:
+      - name: task_run_id
+        tests: [not_null]
+      - name: pipeline_run_id
+      - name: status
+      - name: run_date
+        tests: [not_null]
+
+  - name: stg_pipeline_runs
+    description: Cleaned and typed staging table for pipeline runs.
+    columns:
+      - name: pipeline_run_id
+        tests: [not_null]
+      - name: status
+      - name: run_date
+        tests: [not_null]
+
+  - name: fct_daily_task_run_statuses
+    description: Daily counts of task runs by status.
+    columns:
+      - name: run_date
+        tests: [not_null]
+      - name: status
+        tests: [not_null]
+      - name: run_count
+
+  - name: fct_daily_pipeline_kpis
+    description: Daily pipeline run KPIs including counts and duration metrics.
+    columns:
+      - name: run_date
+        tests: [not_null]
+      - name: num_total
+      - name: num_success
+      - name: num_failed
+      - name: success_rate
+      - name: avg_duration_seconds
+      - name: p50_duration_seconds
+      - name: p90_duration_seconds
+
+  - name: fct_daily_table_row_counts
+    description: Daily row counts of mirrored raw tables.
+    columns:
+      - name: run_date
+        tests: [not_null]
+      - name: table_name
+        tests: [not_null]
+      - name: row_count
+
+  - name: kpi_dashboard
+    description: Consolidated daily KPI table for pipelines and tasks.
+    columns:
+      - name: run_date
+        tests: [not_null]
+

--- a/dbt_projects/motherduck/sources/base.yml
+++ b/dbt_projects/motherduck/sources/base.yml
@@ -1,0 +1,27 @@
+version: 2
+
+sources:
+  - name: md_raw
+    description: Raw snapshots of operational tables mirrored from Postgres into MotherDuck.
+    schema: raw
+    tables:
+      - name: task_runs
+        description: Task run execution records from the operational system.
+      - name: pipeline_runs
+        description: Pipeline run execution records from the operational system.
+
+  - name: md_meta
+    description: Lightweight metadata and statistics extracted during ingestion.
+    schema: meta
+    tables:
+      - name: table_row_counts
+        description: Row counts for mirrored tables at ingestion time.
+      - name: task_run_status_daily
+        description: Daily task run counts by status (computed at extract time).
+      - name: pipeline_run_status_daily
+        description: Daily pipeline run counts by status (computed at extract time).
+      - name: pipeline_run_duration_stats
+        description: Daily duration statistics for pipeline runs (computed at extract time).
+      - name: ingestion_runs
+        description: Audit log for each extraction run.
+


### PR DESCRIPTION
Add a DuckDB SQL script to extract Postgres data into MotherDuck and dbt models to transform it into daily operational insights.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0d4be0b-195a-459c-addb-b5434a16df2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0d4be0b-195a-459c-addb-b5434a16df2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

