### PR TITLE
Add module docstrings

### DIFF
--- a/python/claude_agent/agent.py
+++ b/python/claude_agent/agent.py
@@ -66,9 +66,9 @@ if __name__ == "__main__":
         tools = "Read,Edit,Glob,Bash"
         
     asyncio.run(main(prompt=prompt, tools=tools, github_repo=github_repo))
-    LIGHTDASH_CHART_IDS = os.getenv("LIGHTDASH_CHART_IDS", "No charts found or Lightdash API key not set.")
+    CLAUDE_OUTPUT = os.getenv("CLAUDE_OUTPUT", "No output found")
     orchestra = OrchestraSDK(api_key=os.getenv("ORCHESTRA_API_KEY"))
-    if not LIGHTDASH_CHART_IDS:
+    if not CLAUDE_OUTPUT:
         orchestra.update_task(status=TaskRunStatus.WARNING)
     else:
-        orchestra.set_output(name='LIGHTDASH_CHART_IDS', value=LIGHTDASH_CHART_IDS)
+        orchestra.set_output(name='CLAUDE_OUTPUT', value=CLAUDE_OUTPUT)

--- a/python/claude_agent/agent.py
+++ b/python/claude_agent/agent.py
@@ -41,7 +41,7 @@ async def main(prompt: str, tools: list[str] = ["Read", "Edit", "Glob"], github_
             allowed_tools=tools,
             system_prompt="""You are an autonomous agent. Always look for missing info in environment variables. If you lack enough context after this, raise an error. Do not use the AskUserQuestion tool""",
             permission_mode="bypassPermissions",
-            max_tokens=30000,
+            env={"CLAUDE_CODE_MAX_OUTPUT_TOKENS": "2048"}
         ),
     ):
         if isinstance(message, AssistantMessage):

--- a/python/claude_agent/agent.py
+++ b/python/claude_agent/agent.py
@@ -41,6 +41,7 @@ async def main(prompt: str, tools: list[str] = ["Read", "Edit", "Glob"], github_
             allowed_tools=tools,
             system_prompt="""You are an autonomous agent. Always look for missing info in environment variables. If you lack enough context after this, raise an error. Do not use the AskUserQuestion tool""",
             permission_mode="bypassPermissions",
+            max_tokens=30000,
         ),
     ):
         if isinstance(message, AssistantMessage):

--- a/python/claude_agent/agent.py
+++ b/python/claude_agent/agent.py
@@ -1,3 +1,4 @@
+import ast
 import os
 import subprocess
 import asyncio
@@ -74,6 +75,10 @@ if __name__ == "__main__":
         tools = ["Read", "Edit", "Glob", "Bash"]
         
     CLAUDE_OUTPUT = asyncio.run(main(prompt=prompt, tools=tools, github_repo=github_repo))
+    try:
+        CLAUDE_OUTPUT = ast.literal_eval(CLAUDE_OUTPUT)
+    except:
+        pass
     print(CLAUDE_OUTPUT)
     print(type(CLAUDE_OUTPUT))
     # CLAUDE_OUTPUT = os.getenv("CLAUDE_OUTPUT", "No output found")

--- a/python/claude_agent/agent.py
+++ b/python/claude_agent/agent.py
@@ -1,3 +1,4 @@
+"""Orchestrates autonomous Claude agent execution with GitHub integration for task automation."""
 import ast
 import os
 import subprocess

--- a/python/claude_agent/agent.py
+++ b/python/claude_agent/agent.py
@@ -57,7 +57,7 @@ async def main(prompt: str, tools: list[str] = ["Read", "Edit", "Glob"], github_
                     print(f"Tool: {block.name}")
         elif isinstance(message, ResultMessage):
             print(f"Done: {message.subtype}")
-            final_text = message.content
+            final_text = message.result
     return final_text
 
 
@@ -74,6 +74,8 @@ if __name__ == "__main__":
         tools = ["Read", "Edit", "Glob", "Bash"]
         
     CLAUDE_OUTPUT = asyncio.run(main(prompt=prompt, tools=tools, github_repo=github_repo))
+    print(CLAUDE_OUTPUT)
+    print(type(CLAUDE_OUTPUT))
     # CLAUDE_OUTPUT = os.getenv("CLAUDE_OUTPUT", "No output found")
     orchestra = OrchestraSDK(api_key=os.getenv("ORCHESTRA_API_KEY"))
     if not CLAUDE_OUTPUT:

--- a/python/claude_agent/agent.py
+++ b/python/claude_agent/agent.py
@@ -45,7 +45,7 @@ async def main(prompt: str, tools: list[str] = ["Read", "Edit", "Glob"], github_
             system_prompt="""You are an autonomous agent. Always look for missing info in environment variables. If you lack enough context after this, raise an error. Do not use the AskUserQuestion tool""",
             permission_mode="bypassPermissions",
             env={"CLAUDE_CODE_MAX_OUTPUT_TOKENS": "2048"},
-            max_turns=5,
+            # max_turns=5,
             setting_sources=[]
         ),
     ):

--- a/python/claude_agent/agent.py
+++ b/python/claude_agent/agent.py
@@ -41,7 +41,8 @@ async def main(prompt: str, tools: list[str] = ["Read", "Edit", "Glob"], github_
             allowed_tools=tools,
             system_prompt="""You are an autonomous agent. Always look for missing info in environment variables. If you lack enough context after this, raise an error. Do not use the AskUserQuestion tool""",
             permission_mode="bypassPermissions",
-            env={"CLAUDE_CODE_MAX_OUTPUT_TOKENS": "2048"}
+            env={"CLAUDE_CODE_MAX_OUTPUT_TOKENS": "2048"},
+            max_turns=5
         ),
     ):
         if isinstance(message, AssistantMessage):

--- a/python/claude_agent/agent.py
+++ b/python/claude_agent/agent.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     try:
         tools = os.getenv("TOOLS").split(",") 
     except:
-        tools = "Read,Edit,Glob,Bash"
+        tools = ["Read", "Edit", "Glob", "Bash"]
         
     asyncio.run(main(prompt=prompt, tools=tools, github_repo=github_repo))
     CLAUDE_OUTPUT = os.getenv("CLAUDE_OUTPUT", "No output found")

--- a/python/claude_agent/agent.py
+++ b/python/claude_agent/agent.py
@@ -38,14 +38,17 @@ async def main(prompt: str, tools: list[str] = ["Read", "Edit", "Glob"], github_
     async for message in query(
         prompt=f"""{prompt}""",
         options=ClaudeAgentOptions(
+            model="claude-haiku-4-5",
             allowed_tools=tools,
             system_prompt="""You are an autonomous agent. Always look for missing info in environment variables. If you lack enough context after this, raise an error. Do not use the AskUserQuestion tool""",
             permission_mode="bypassPermissions",
             env={"CLAUDE_CODE_MAX_OUTPUT_TOKENS": "2048"},
-            max_turns=5
+            max_turns=5,
+            setting_sources=[]
         ),
     ):
         if isinstance(message, AssistantMessage):
+            print("Usage: ", message.usage)
             for block in message.content:
                 if hasattr(block, "text"):
                     print(block.text)

--- a/python/claude_agent/agent.py
+++ b/python/claude_agent/agent.py
@@ -35,6 +35,7 @@ async def main(prompt: str, tools: list[str] = ["Read", "Edit", "Glob"], github_
         token = os.environ["GITHUB_TOKEN"]
         setup_git_auth(token, github_repo)
 
+    final_text = None
     async for message in query(
         prompt=f"""{prompt}""",
         options=ClaudeAgentOptions(
@@ -56,6 +57,8 @@ async def main(prompt: str, tools: list[str] = ["Read", "Edit", "Glob"], github_
                     print(f"Tool: {block.name}")
         elif isinstance(message, ResultMessage):
             print(f"Done: {message.subtype}")
+            final_text = message.content
+    return final_text
 
 
 if __name__ == "__main__":
@@ -70,8 +73,8 @@ if __name__ == "__main__":
     except:
         tools = ["Read", "Edit", "Glob", "Bash"]
         
-    asyncio.run(main(prompt=prompt, tools=tools, github_repo=github_repo))
-    CLAUDE_OUTPUT = os.getenv("CLAUDE_OUTPUT", "No output found")
+    CLAUDE_OUTPUT = asyncio.run(main(prompt=prompt, tools=tools, github_repo=github_repo))
+    # CLAUDE_OUTPUT = os.getenv("CLAUDE_OUTPUT", "No output found")
     orchestra = OrchestraSDK(api_key=os.getenv("ORCHESTRA_API_KEY"))
     if not CLAUDE_OUTPUT:
         orchestra.update_task(status=TaskRunStatus.WARNING)

--- a/python/claude_agent/main.py
+++ b/python/claude_agent/main.py
@@ -1,0 +1,9 @@
+"""Entry point for the claude-agent module."""
+
+
+def main():
+    print("Hello from claude-agent!")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/claude_agent/tests/test_postgres_connector.py
+++ b/python/claude_agent/tests/test_postgres_connector.py
@@ -1,0 +1,151 @@
+"""Unit tests for postgres_connector.py mock implementation."""
+
+import pytest
+import sys
+from pathlib import Path
+
+# Add the postgres module to the path
+postgres_path = Path(__file__).parent.parent.parent / "postgres"
+sys.path.insert(0, str(postgres_path))
+
+from postgres_connector import PostgreSQLConnector, MockConnection, MockCursor, MOCK_USERS
+
+
+class TestMockCursor:
+    """Tests for MockCursor class."""
+
+    def test_cursor_executes_fetch_all_query(self):
+        """Test that cursor can execute a query and fetch all results."""
+        cursor = MockCursor(MOCK_USERS)
+        cursor.execute("SELECT * FROM users;")
+        results = cursor.fetchall()
+        assert len(results) == 4
+        assert results[0] == (1, "Alice", "alice@example.com", "2024-01-01")
+
+    def test_cursor_fetch_by_id(self):
+        """Test fetching a user by id with WHERE clause."""
+        cursor = MockCursor(MOCK_USERS)
+        cursor.execute("SELECT * FROM users WHERE id = %s;", (2,))
+        result = cursor.fetchone()
+        assert result == (2, "Bob", "bob@example.com", "2024-01-05")
+
+    def test_cursor_filter_by_email_pattern(self):
+        """Test filtering users by email pattern."""
+        cursor = MockCursor(MOCK_USERS)
+        cursor.execute("SELECT * FROM users WHERE email LIKE %s;", ("%@example.com",))
+        results = cursor.fetchall()
+        assert len(results) == 3  # Alice, Bob, Diana
+        assert all("example.com" in str(row) for row in results)
+
+    def test_cursor_order_by_desc(self):
+        """Test ordering results by created_at in descending order."""
+        cursor = MockCursor(MOCK_USERS)
+        cursor.execute("SELECT * FROM users ORDER BY created_at DESC;")
+        results = cursor.fetchall()
+        assert results[0][3] == "2024-02-01"  # Diana (most recent)
+        assert results[-1][3] == "2024-01-01"  # Alice (oldest)
+
+    def test_cursor_count_query(self):
+        """Test COUNT query returns count of results."""
+        cursor = MockCursor(MOCK_USERS)
+        cursor.execute("SELECT COUNT(*) FROM users;")
+        result = cursor.fetchone()
+        assert result == (4,)
+
+    def test_cursor_fetchmany(self):
+        """Test fetching limited number of rows."""
+        cursor = MockCursor(MOCK_USERS)
+        cursor.execute("SELECT * FROM users;")
+        results = cursor.fetchmany(2)
+        assert len(results) == 2
+
+    def test_cursor_rowcount(self):
+        """Test that rowcount property returns correct count."""
+        cursor = MockCursor(MOCK_USERS)
+        cursor.execute("SELECT * FROM users;")
+        assert cursor.rowcount == 4
+
+    def test_cursor_context_manager(self):
+        """Test that cursor works as context manager."""
+        cursor = MockCursor(MOCK_USERS)
+        with cursor as c:
+            assert c is cursor
+
+
+class TestMockConnection:
+    """Tests for MockConnection class."""
+
+    def test_connection_creates_cursor(self):
+        """Test that connection can create a cursor."""
+        conn = MockConnection()
+        cursor = conn.cursor()
+        assert isinstance(cursor, MockCursor)
+
+    def test_connection_commit(self):
+        """Test that connection commit doesn't raise error."""
+        conn = MockConnection()
+        conn.commit()  # Should not raise
+
+    def test_connection_context_manager(self):
+        """Test that connection works as context manager."""
+        with MockConnection() as conn:
+            assert isinstance(conn, MockConnection)
+
+
+class TestPostgreSQLConnector:
+    """Tests for PostgreSQLConnector class."""
+
+    def test_connector_initialization(self):
+        """Test that connector initializes successfully."""
+        db = PostgreSQLConnector()
+        assert db.pool is True
+
+    def test_fetch_all_returns_all_users(self):
+        """Test fetching all users returns a list of dictionaries."""
+        db = PostgreSQLConnector()
+        results = db.fetch_all("SELECT * FROM users;")
+        assert len(results) == 4
+        assert results[0] == {"id": 1, "name": "Alice", "email": "alice@example.com", "created_at": "2024-01-01"}
+
+    def test_fetch_one_returns_single_user(self):
+        """Test fetching a single user by id."""
+        db = PostgreSQLConnector()
+        result = db.fetch_one("SELECT * FROM users WHERE id = %s;", (1,))
+        assert result["name"] == "Alice"
+        assert result["id"] == 1
+
+    def test_fetch_one_returns_none_for_no_results(self):
+        """Test that fetch_one returns None when no results found."""
+        db = PostgreSQLConnector()
+        result = db.fetch_one("SELECT * FROM users WHERE id = %s;", (999,))
+        assert result is None
+
+    def test_fetch_many_with_limit(self):
+        """Test fetching limited number of users."""
+        db = PostgreSQLConnector()
+        results = db.fetch_many("SELECT * FROM users;", limit=2)
+        assert len(results) == 2
+
+    def test_fetch_many_returns_none_for_no_results(self):
+        """Test that fetch_many returns None when no results found."""
+        db = PostgreSQLConnector()
+        result = db.fetch_many("SELECT * FROM users WHERE id = %s;", limit=5, params=(999,))
+        assert result is None
+
+    def test_fetch_all_with_filter(self):
+        """Test fetching all users filtered by email domain."""
+        db = PostgreSQLConnector()
+        results = db.fetch_all("SELECT * FROM users WHERE email LIKE %s;", ("%@example.com",))
+        assert len(results) == 3
+        assert all("example.com" in user["email"] for user in results)
+
+    def test_execute_query_returns_true(self):
+        """Test that execute_query returns True."""
+        db = PostgreSQLConnector()
+        result = db.execute_query("DELETE FROM users WHERE id = %s;", (1,))
+        assert result is True
+
+    def test_close_connector(self):
+        """Test that close method executes without error."""
+        db = PostgreSQLConnector()
+        db.close()  # Should not raise

--- a/python/claude_agent/tests/test_utils.py
+++ b/python/claude_agent/tests/test_utils.py
@@ -1,0 +1,82 @@
+"""Unit tests for utils.py module."""
+
+import pytest
+from claude_agent.utils import calculate_average, get_user_name
+
+
+class TestCalculateAverage:
+    """Tests for calculate_average function."""
+
+    def test_calculate_average_with_valid_numbers(self):
+        """Test average calculation with a list of valid numbers."""
+        assert calculate_average([1, 2, 3, 4, 5]) == 3.0
+
+    def test_calculate_average_with_floats(self):
+        """Test average calculation with float values."""
+        assert calculate_average([1.5, 2.5, 3.0]) == pytest.approx(2.333, rel=0.01)
+
+    def test_calculate_average_with_empty_list(self):
+        """Test that empty list returns 0.0."""
+        assert calculate_average([]) == 0.0
+
+    def test_calculate_average_with_mixed_valid_and_invalid(self):
+        """Test average skips non-numeric values but divides by total count."""
+        # Note: function divides by len(numbers), not len(numeric_values)
+        result = calculate_average([1, "invalid", 3, None, 5])
+        # sum = 1 + 3 + 5 = 9, len = 5, avg = 9/5 = 1.8
+        assert result == pytest.approx(1.8)
+
+    def test_calculate_average_single_value(self):
+        """Test average with a single numeric value."""
+        assert calculate_average([42]) == 42.0
+
+    def test_calculate_average_with_negative_numbers(self):
+        """Test average with negative numbers."""
+        assert calculate_average([-5, -3, 2]) == pytest.approx(-2.0)
+
+
+class TestGetUserName:
+    """Tests for get_user_name function."""
+
+    def test_get_user_name_with_valid_user(self):
+        """Test extracting and uppercasing a valid user name."""
+        user = {"name": "alice", "email": "alice@example.com"}
+        assert get_user_name(user) == "ALICE"
+
+    def test_get_user_name_with_uppercase_input(self):
+        """Test that name is returned in uppercase even if already uppercase."""
+        user = {"name": "BOB"}
+        assert get_user_name(user) == "BOB"
+
+    def test_get_user_name_with_mixed_case(self):
+        """Test uppercase conversion for mixed case names."""
+        user = {"name": "ChArLiE"}
+        assert get_user_name(user) == "CHARLIE"
+
+    def test_get_user_name_missing_name_key(self):
+        """Test that None is returned when 'name' key is missing."""
+        user = {"email": "user@example.com"}
+        assert get_user_name(user) is None
+
+    def test_get_user_name_with_none_value(self):
+        """Test that None is returned when 'name' key has None value."""
+        user = {"name": None}
+        assert get_user_name(user) is None
+
+    def test_get_user_name_with_non_dict_input(self):
+        """Test that None is returned for non-dictionary input."""
+        assert get_user_name("not a dict") is None
+        assert get_user_name(None) is None
+        assert get_user_name(123) is None
+
+    def test_get_user_name_with_non_string_name_value(self):
+        """Test that None is returned when name value is not a string."""
+        user = {"name": 123}
+        assert get_user_name(user) is None
+        user = {"name": ["list"]}
+        assert get_user_name(user) is None
+
+    def test_get_user_name_with_empty_string(self):
+        """Test that empty string is still returned as uppercase."""
+        user = {"name": ""}
+        assert get_user_name(user) == ""

--- a/python/claude_agent/utils.py
+++ b/python/claude_agent/utils.py
@@ -1,3 +1,6 @@
+"""Utility functions for data processing and transformation."""
+
+
 def calculate_average(numbers):
     """Calculate the average of a list of numbers.
 


### PR DESCRIPTION
Add module-level docstrings to Python modules explaining their purpose.

## Modules Updated

- `agent.py`: Orchestrates autonomous Claude agent execution with GitHub integration for task automation
- `utils.py`: Utility functions for data processing and transformation
- `main.py`: Entry point for the claude-agent module
- `postgres_connector.py`: Already had docstring, no changes needed