### PR TITLE
fix: add pyproject.toml for UV package manager

### DIFF
--- a/dbt_projects/snowflake/pyproject.toml
+++ b/dbt_projects/snowflake/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "dbt-snowflake"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "dbt-snowflake==1.11.3",
+    "dbt-core==1.11.7",
+]


### PR DESCRIPTION
## Summary
- UV package manager requires `pyproject.toml` to install dependencies before running dbt
- `dbt_projects/snowflake` on `broken-dbt` had `requirements.txt` but no `pyproject.toml`
- This caused Orchestra pipeline `#fivetran #dbt #lightdash Failing Pipeline` to fail at the dependency install step

## Change
Added `dbt_projects/snowflake/pyproject.toml` with the same dependencies already in `requirements.txt` (`dbt-snowflake==1.11.3`, `dbt-core==1.11.7`).

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger the Orchestra pipeline on `broken-dbt` — dbt Core task should now pass the UV install step and proceed to `dbt build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)