### PR TITLE
fix: restore average test threshold to 2000 on store_sales_example

### DIFF
--- a/dbt_projects/snowflake/models/clean/schema.yml
+++ b/dbt_projects/snowflake/models/clean/schema.yml
@@ -34,7 +34,7 @@ models:
     description: "Example store sales"
     tests:
       - average:
-          threshold: 0
+          threshold: 2000
           average_field: sales
           date_field: date
           null_filter: store


### PR DESCRIPTION
## Summary

- `threshold` in `dbt_projects/snowflake/models/clean/schema.yml` was set to `0` instead of `2000` on the `broken-dbt` branch
- This caused the `average_store_sales` custom test to compile to `WHERE avg_ > 0`, matching all 57 store/date combinations and failing the build
- Restores threshold to `2000` (matching the `main` branch value)

## Test plan

- [ ] Merge this PR into `broken-dbt`
- [ ] Re-trigger the Orchestra pipeline — `dbt build` should pass the `average_store_sales_example_sales__date__store__0` test

🤖 Generated with [Claude Code](https://claude.com/claude-code)