### PR TITLE
fix: restore average test threshold to 2000 on store_sales_example

### DIFF
--- a/dbt_projects/snowflake/models/clean/schema.yml
+++ b/dbt_projects/snowflake/models/clean/schema.yml
@@ -34,7 +34,7 @@ models:
     description: "Example store sales"
     tests:
       - average:
-          threshold: 0
+          threshold: 2000
           average_field: sales
           date_field: date
           null_filter: store


### PR DESCRIPTION
## Summary

- Commit `51e0d3a` accidentally changed the `average` dbt test threshold on `store_sales_example` from `2000` to `0`
- This caused 57 rows to fail `average_store_sales_example_sales__date__store__0` in `models/clean/schema.yml`
- Restores threshold to `2000`, matching the last known-good commit (`bdd3eb1`)

## Test plan

- [ ] Merge this PR into `broken-dbt`
- [ ] Verify the Orchestra pipeline `#fivetran #dbt #lightdash Failing Pipeline` reruns and the dbt build passes
- [ ] Confirm Lightdash refresh task runs (no longer skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)