### PR TITLE
fix: restore average test threshold to 2000 on store_sales_example

### DIFF
--- a/dbt_projects/snowflake/models/clean/schema.yml
+++ b/dbt_projects/snowflake/models/clean/schema.yml
@@ -34,7 +34,7 @@ models:
     description: "Example store sales"
     tests:
       - average:
-          threshold: 0
+          threshold: 2000
           average_field: sales
           date_field: date
           null_filter: store


### PR DESCRIPTION
## Summary
- Restores `threshold: 2000` on the `average` test for `store_sales_example` in `models/clean/schema.yml`
- Reverts the revert (PR #181) which set the threshold to `0`, causing `dbt build` to fail with 57 violations
- This is the same fix as PRs #178 and #180, both of which passed when merged

## Root cause
The `average_store_sales` test checks that average store sales by (date, store) meet a minimum threshold. With `threshold: 0`, the test returns all 57 rows where store sales exist — they all trivially violate a floor of 0. The correct threshold is `2000`.

## Test plan
- [ ] Merge this PR
- [ ] Pipeline run on `broken-dbt` branch should produce `PASS=83 WARN=2 ERROR=0`
- [ ] Lightdash refresh task should run (not be skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)