### PR TITLE
Stabilize lint baseline and exclude local worktrees

### DIFF
--- a/CLEANUP_PLAN.md
+++ b/CLEANUP_PLAN.md
@@ -277,7 +277,7 @@ main PRs land._
 
 - [ ] ci Makefile:7 — make validate/lint/audit targets exist but are not enforced by any workflow end-to-end — Add shared CI workflow gating PRs on validate + lint + security + dependency audit
 - [ ] pipelines orchestra/:1 — `make validate lint` currently fails on baseline yamllint violations across many existing orchestra YAML files (indentation/line-length/document-start), blocking clean gate runs for unrelated branches — Triage and remediate in scoped pipelines cleanup branches
-- [ ] python repo:1 — `make lint` currently fails on baseline out-of-scope Ruff violations (for example: bauplan/scan.py F841, dlt/hubspot/__init__.py F401, python/reverse_etl.py F811, python/claude_agent/agent.py E722), blocking clean gate runs for unrelated branches — Triage and remediate in scoped cleanup/python branches
+- [x] python repo:1 — `make lint` currently fails on baseline out-of-scope Ruff violations (for example: bauplan/scan.py F841, dlt/hubspot/__init__.py F401, python/reverse_etl.py F811, python/claude_agent/agent.py E722), blocking clean gate runs for unrelated branches — Triage and remediate in scoped cleanup/python branches
 - [x] docs README.md:5 — Structure cleanup item deferred from cleanup/structure (reserved-file rule): root README index missing azure, estuary, hybrid_deploy, multi_workspace_test — Handle on cleanup/docs
 - [x] docs README.md:29 — Structure cleanup item deferred from cleanup/structure (reserved-file rule): README 'Analytics' section has no matching top-level directory — Handle on cleanup/docs
 - [x] docs README.md:67 — Structure cleanup item deferred from cleanup/structure (reserved-file rule): README 'Sensors' section has no matching top-level directory — Handle on cleanup/docs

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ validate-pipelines:
 	exit $$fail
 
 lint:
-	ruff check .
-	ruff format --check .
+	ruff check . --exclude worktrees
+	ruff format --check . --exclude worktrees
 
 audit:
 	gitleaks detect --no-banner --redact

--- a/azure/ml/scripts/prep_data.py
+++ b/azure/ml/scripts/prep_data.py
@@ -58,12 +58,14 @@ class MockAzureMLWorkspace:
         log(f"Model deployed to endpoint: {endpoint}", LogStyle.SUCCESS)
         return endpoint
 
-    def run_inference(self, endpoint: str, input_data: dict[str, Any]) -> dict[str, Any]:
+    def run_inference(
+        self, endpoint: str, input_data: dict[str, Any]
+    ) -> dict[str, Any]:
         log(f"Calling model endpoint: {endpoint}")
         log(f"Input: {input_data}")
         simulated_output = {
             "prediction": random.choice(["cat", "dog", "chicken", "robot"]),
-            "confidence": round(random.uniform(0.8, 0.99), 4)
+            "confidence": round(random.uniform(0.8, 0.99), 4),
         }
         time.sleep(1)
         log(f"Output: {simulated_output}", LogStyle.SUCCESS)
@@ -75,13 +77,17 @@ if __name__ == "__main__":
     workspace = MockAzureMLWorkspace(
         name="my-ml-workspace",
         subscription_id="1234-5678-9012",
-        resource_group="my-resource-group"
+        resource_group="my-resource-group",
     )
 
-    model_id = workspace.register_model("image_classifier", "./models/image_classifier.pkl")
+    model_id = workspace.register_model(
+        "image_classifier", "./models/image_classifier.pkl"
+    )
     run_id = workspace.submit_experiment("train_classifier", "train_classifier.py")
     workspace.monitor_run(run_id)
     endpoint = workspace.deploy_model(model_id, "image-service")
-    output = workspace.run_inference(endpoint, {"image_url": "https://example.com/cat.jpg"})
+    output = workspace.run_inference(
+        endpoint, {"image_url": "https://example.com/cat.jpg"}
+    )
 
     log("All operations completed (mocked)", LogStyle.SUCCESS)

--- a/azure/ml/scripts/train.py
+++ b/azure/ml/scripts/train.py
@@ -58,12 +58,14 @@ class MockAzureMLWorkspace:
         log(f"Model deployed to endpoint: {endpoint}", LogStyle.SUCCESS)
         return endpoint
 
-    def run_inference(self, endpoint: str, input_data: dict[str, Any]) -> dict[str, Any]:
+    def run_inference(
+        self, endpoint: str, input_data: dict[str, Any]
+    ) -> dict[str, Any]:
         log(f"Calling model endpoint: {endpoint}")
         log(f"Input: {input_data}")
         simulated_output = {
             "prediction": random.choice(["cat", "dog", "chicken", "robot"]),
-            "confidence": round(random.uniform(0.8, 0.99), 4)
+            "confidence": round(random.uniform(0.8, 0.99), 4),
         }
         time.sleep(1)
         log(f"Output: {simulated_output}", LogStyle.SUCCESS)
@@ -75,13 +77,17 @@ if __name__ == "__main__":
     workspace = MockAzureMLWorkspace(
         name="my-ml-workspace",
         subscription_id="1234-5678-9012",
-        resource_group="my-resource-group"
+        resource_group="my-resource-group",
     )
 
-    model_id = workspace.register_model("image_classifier", "./models/image_classifier.pkl")
+    model_id = workspace.register_model(
+        "image_classifier", "./models/image_classifier.pkl"
+    )
     run_id = workspace.submit_experiment("train_classifier", "train_classifier.py")
     workspace.monitor_run(run_id)
     endpoint = workspace.deploy_model(model_id, "image-service")
-    output = workspace.run_inference(endpoint, {"image_url": "https://example.com/cat.jpg"})
+    output = workspace.run_inference(
+        endpoint, {"image_url": "https://example.com/cat.jpg"}
+    )
 
     log("All operations completed (mocked)", LogStyle.SUCCESS)

--- a/dbt_projects/postgres/db/scripts/create_db_insert_data.py
+++ b/dbt_projects/postgres/db/scripts/create_db_insert_data.py
@@ -18,11 +18,11 @@ logger = logging.getLogger(__name__)
 def get_conn():
     logger.info("Creating Database Connection...")
     conn = psycopg2.connect(
-        database=os.getenv('POSTGRES_DB'),
-        user=os.getenv('POSTGRES_USER'),
-        password=os.getenv('POSTGRES_PASSWORD'),
-        host=os.getenv('POSTGRES_HOST'),
-        port=os.getenv('POSTGRES_PORT'),
+        database=os.getenv("POSTGRES_DB"),
+        user=os.getenv("POSTGRES_USER"),
+        password=os.getenv("POSTGRES_PASSWORD"),
+        host=os.getenv("POSTGRES_HOST"),
+        port=os.getenv("POSTGRES_PORT"),
     )
 
     cur = conn.cursor()
@@ -55,7 +55,9 @@ if __name__ == "__main__":
 
     for file in files.keys():
         tablename = files[file]
-        data = pd.read_csv(Path(__file__).resolve().parent.parent / "data/{}".format(file))
+        data = pd.read_csv(
+            Path(__file__).resolve().parent.parent / "data/{}".format(file)
+        )
 
         try:
             logger.info(

--- a/dlt/google_sheets/__init__.py
+++ b/dlt/google_sheets/__init__.py
@@ -70,9 +70,9 @@ def google_spreadsheet(
         spreadsheet_id=spreadsheet_id,
         range_names=list(all_range_names),
     )
-    assert len(all_range_names) == len(
-        all_range_data
-    ), "Google Sheets API must return values for all requested ranges"
+    assert len(all_range_names) == len(all_range_data), (
+        "Google Sheets API must return values for all requested ranges"
+    )
 
     # get metadata for two first rows of each range
     # first should contain headers
@@ -126,7 +126,7 @@ def google_spreadsheet(
         headers = get_range_headers(headers_metadata, name)
         if headers is None:
             # generate automatic headers and treat the first row as data
-            headers = [f"col_{idx+1}" for idx in range(len(headers_metadata))]
+            headers = [f"col_{idx + 1}" for idx in range(len(headers_metadata))]
             data_row_metadata = headers_metadata
             rows_data = values[0:]
             logger.warning(

--- a/dlt/google_sheets/helpers/data_processing.py
+++ b/dlt/google_sheets/helpers/data_processing.py
@@ -31,6 +31,7 @@ __all__ = [
     "process_range",
 ]
 
+
 def get_spreadsheet_id(url_or_id: str) -> str:
     """
     Receives an ID or URL to a Google Spreadsheet and returns the spreadsheet ID as a string.
@@ -104,12 +105,12 @@ def get_range_headers(headers_metadata: List[DictStrAny], range_name: str) -> Li
                     header_val = str(f"col_{idx + 1}")
                 else:
                     logger.warning(
-                        f"In range {range_name}, header value: {header_val} at position {idx+1} is not a string!"
+                        f"In range {range_name}, header value: {header_val} at position {idx + 1} is not a string!"
                     )
                     return None
         else:
             logger.warning(
-                f"In range {range_name}, header at position {idx+1} is not missing!"
+                f"In range {range_name}, header at position {idx + 1} is not missing!"
             )
             return None
         headers.append(header_val)
@@ -269,5 +270,3 @@ def process_range(
                 fill_val = val
             table_dict[header] = fill_val
         yield table_dict
-
-

--- a/dlt/hubspot_pipeline.py
+++ b/dlt/hubspot_pipeline.py
@@ -5,9 +5,9 @@ from hubspot import hubspot, hubspot_events_for_objects, THubspotObjectType
 from setup_logger import build_logger
 
 
-
-
 logger = build_logger("debug.log")
+
+
 def run_pipeline() -> None:
     """
     This function loads all resources from HubSpot CRM
@@ -21,11 +21,13 @@ def run_pipeline() -> None:
     p = dlt.pipeline(
         pipeline_name="hubspot",
         dataset_name="dlt_hubspot",
-        destination='bigquery',
+        destination="bigquery",
     )
 
     data = hubspot()
-    data.companies.bind(props=['hs_time_in_opportunity', 'hs_analytics_first_visit_timestamp'])
+    data.companies.bind(
+        props=["hs_time_in_opportunity", "hs_analytics_first_visit_timestamp"]
+    )
 
     # Run the pipeline with the HubSpot source connector
     info = p.run(data)
@@ -49,7 +51,7 @@ def load_crm_data_with_history() -> None:
     p = dlt.pipeline(
         pipeline_name="hubspot",
         dataset_name="hubspot_dataset",
-        destination='bigquery',
+        destination="bigquery",
     )
 
     # Configure the source with `include_history` to enable property history load, history is disabled by default
@@ -74,7 +76,7 @@ def load_crm_objects_with_custom_properties() -> None:
     p = dlt.pipeline(
         pipeline_name="hubspot",
         dataset_name="hubspot_dataset",
-        destination='bigquery',
+        destination="bigquery",
     )
 
     source = hubspot()
@@ -109,7 +111,7 @@ def load_web_analytics_events(
     p = dlt.pipeline(
         pipeline_name="hubspot",
         dataset_name="hubspot_dataset",
-        destination='bigquery',
+        destination="bigquery",
         dev_mode=False,
     )
 
@@ -120,4 +122,3 @@ def load_web_analytics_events(
 
     # Print information about the pipeline run
     print(info)
-

--- a/patterns/warehouse_savings/_warehouse_plotting.py
+++ b/patterns/warehouse_savings/_warehouse_plotting.py
@@ -54,13 +54,17 @@ def plot_total_operation_duration_by_state_orchestration(
     if "insertedAt" in ops_df.columns:
         ops_df["insertedAt"] = pd.to_datetime(ops_df["insertedAt"], errors="coerce")
     if "createdAt" in task_runs_df.columns:
-        task_runs_df["createdAt"] = pd.to_datetime(task_runs_df["createdAt"], errors="coerce")
+        task_runs_df["createdAt"] = pd.to_datetime(
+            task_runs_df["createdAt"], errors="coerce"
+        )
 
     if "taskParameters" in task_runs_df.columns:
         task_runs_df["use_state_orchestration"] = task_runs_df["taskParameters"].apply(
-            lambda x: x.get("use_state_orchestration", False)
-            if isinstance(x, dict)
-            else False,
+            lambda x: (
+                x.get("use_state_orchestration", False)
+                if isinstance(x, dict)
+                else False
+            ),
         )
     else:
         task_runs_df["use_state_orchestration"] = False
@@ -147,7 +151,9 @@ def plot_total_operation_duration_by_state_orchestration(
         before = task_data[task_data["days_from_first_use"] < 0]
         after = task_data[task_data["days_from_first_use"] >= 0]
 
-        avg_before = before["total_duration_seconds"].mean() if not before.empty else None
+        avg_before = (
+            before["total_duration_seconds"].mean() if not before.empty else None
+        )
         avg_after = after["total_duration_seconds"].mean() if not after.empty else None
 
         if avg_before is not None and avg_after is not None and avg_before > 0:
@@ -210,7 +216,10 @@ def plot_total_operation_duration_by_state_orchestration(
         fontsize=TITLE_FONTSIZE,
         fontweight="bold",
     )
-    ax.set_xlabel("Days from First State Orchestration Use (0 = first use)", fontsize=AXIS_LABEL_FONTSIZE)
+    ax.set_xlabel(
+        "Days from First State Orchestration Use (0 = first use)",
+        fontsize=AXIS_LABEL_FONTSIZE,
+    )
     ax.set_ylabel("Total Duration (seconds)", fontsize=AXIS_LABEL_FONTSIZE)
     ax.grid(True, alpha=GRID_ALPHA, linestyle="--")
 
@@ -243,7 +252,9 @@ def plot_total_operation_duration_by_state_orchestration(
         table_data.append(
             [
                 stat["task_name"],
-                f"{stat['avg_before']:.1f}" if stat["avg_before"] is not None else "N/A",
+                f"{stat['avg_before']:.1f}"
+                if stat["avg_before"] is not None
+                else "N/A",
                 f"{stat['avg_after']:.1f}" if stat["avg_after"] is not None else "N/A",
                 f"{change_str} {color_indicator}",
             ],

--- a/patterns/warehouse_savings/graph.py
+++ b/patterns/warehouse_savings/graph.py
@@ -2,7 +2,11 @@ import os
 
 import matplotlib.pyplot as plt
 
-from _warehouse_api import DEFAULT_ANALYSIS_DAYS, OrchestraAPIClient, calculate_time_range
+from _warehouse_api import (
+    DEFAULT_ANALYSIS_DAYS,
+    OrchestraAPIClient,
+    calculate_time_range,
+)
 from _warehouse_plotting import (
     FIGURE_HEIGHT,
     FIGURE_WIDTH,

--- a/python/integration_a/computation.py
+++ b/python/integration_a/computation.py
@@ -1,8 +1,9 @@
 import time
 import numpy as np
-import os 
+import os
 import json
 import requests
+
 
 def power_iteration(A, num_simulations=2500):
     # Starting with a random vector
@@ -15,6 +16,7 @@ def power_iteration(A, num_simulations=2500):
     # Estimate the eigenvalue from the result
     eigenvalue = np.dot(b_k.T, np.dot(A, b_k))
     return eigenvalue
+
 
 def intensive_power_iteration():
     print("Starting power iteration computation...")
@@ -29,21 +31,22 @@ def intensive_power_iteration():
     print(f"Elapsed time: {end_time - start_time:.2f} seconds")
     print(f"Largest estimated eigenvalue: {largest_eigenvalue:.4f}")
 
-#intensive_power_iteration()
+
+# intensive_power_iteration()
 
 data = {
     "event_type": "SET_OUTPUT",
-    "task_run_id": os.getenv('ORCHESTRA_TASK_RUN_ID'),  # Replace with actual taskRunId
+    "task_run_id": os.getenv("ORCHESTRA_TASK_RUN_ID"),  # Replace with actual taskRunId
     "output_name": "DBT_TABLES",
-    "output_value": "event_parameters+ deals_clean+"
+    "output_value": "event_parameters+ deals_clean+",
 }
 
 url = "https://webhook.getorchestra.io"
-api_key = os.getenv('ORCHESTRA_API_KEY')
+api_key = os.getenv("ORCHESTRA_API_KEY")
 # Set headers with Bearer authentication
 headers = {
     "Content-Type": "application/json",
-    "Authorization": f"Bearer {api_key}" # Replace with actual orchestra_api_key
+    "Authorization": f"Bearer {api_key}",  # Replace with actual orchestra_api_key
 }
 
 response = requests.post(url, headers=headers, data=json.dumps(data))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Objective
Reduce cross-cutting lint noise so cleanup checks reflect repository code rather than local agent artifacts.

## Changes
- Updated lint target to ignore local `worktrees/` paths that are not repository source.
- Applied formatter normalization to files still failing `ruff format --check`.
- Checked off the corresponding cross-cutting Python lint follow-up in the cleanup plan.

## Testing
`make lint` now passes. `make validate lint` still fails on the existing repository-wide yamllint baseline issues tracked in cleanup follow-ups.

## Checklist
- [x] Verified these changes are backwards compatible (db migrations, model updates)

## Additional Notes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e73e2fba-78dd-42fd-864f-1beab7aa79fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e73e2fba-78dd-42fd-864f-1beab7aa79fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

