### PR TITLE
Add accurate docstrings to staging models

### DIFF
--- a/dbt_projects/snowflake/models/staging/oil_area_staging.sql
+++ b/dbt_projects/snowflake/models/staging/oil_area_staging.sql
@@ -1,22 +1,23 @@
 {{ config(materialized='view') }}
 
 /*
-  Model: marketing_data_staging
+  Model: oil_area_staging
   Description:
-    Staging model that surfaces Google Analytics marketing data from the
-    ga_data_clean layer. The upstream CTE references (base, tasks) act as
-    dependency anchors, confirming that customer data is present and
-    consistent before the final output is produced.
+    Staging model that surfaces oil-field area-level data from the
+    oil_data_clean layer. The upstream CTE references (base, tasks) act as
+    dependency anchors, confirming that customer data is present and that
+    oil_data_clean is materialized before the final output is produced.
 
-    All columns from ga_data_clean are passed through without transformation,
-    making this model the canonical staging source for marketing / web
-    analytics consumption in downstream reporting and attribution models.
+    All columns from oil_data_clean are passed through without transformation,
+    making this model the canonical staging source for area-level oil field
+    aggregations consumed by downstream production / reservoir reporting
+    models.
 
   Upstream models:
     - customers_clean : Validates customer dimension availability
-    - ga_data_clean   : Primary source — all GA marketing event columns
-                        surfaced downstream (e.g. sessions, conversions,
-                        traffic source, campaign data)
+    - oil_data_clean  : Primary source — all oil-field area columns are
+                        surfaced downstream (e.g. area identifiers, basin /
+                        field metadata, geospatial attributes)
 */
 
 with base as (

--- a/dbt_projects/snowflake/models/staging/oil_production_staging.sql
+++ b/dbt_projects/snowflake/models/staging/oil_production_staging.sql
@@ -1,22 +1,23 @@
 {{ config(materialized='view') }}
 
 /*
-  Model: marketing_data_staging
+  Model: oil_production_staging
   Description:
-    Staging model that surfaces Google Analytics marketing data from the
-    ga_data_clean layer. The upstream CTE references (base, tasks) act as
-    dependency anchors, confirming that customer data is present and
-    consistent before the final output is produced.
+    Staging model that surfaces oil production data from the oil_data_clean
+    layer. The upstream CTE references (base, tasks) act as dependency
+    anchors, confirming that customer data is available and that
+    oil_data_clean has been refreshed before the final output is produced.
 
-    All columns from ga_data_clean are passed through without transformation,
-    making this model the canonical staging source for marketing / web
-    analytics consumption in downstream reporting and attribution models.
+    All columns from oil_data_clean are passed through without transformation,
+    making this model the canonical staging source for oil production
+    metrics (e.g. barrels produced, well-level output, production date
+    ranges) consumed by downstream reporting and forecasting models.
 
   Upstream models:
     - customers_clean : Validates customer dimension availability
-    - ga_data_clean   : Primary source — all GA marketing event columns
-                        surfaced downstream (e.g. sessions, conversions,
-                        traffic source, campaign data)
+    - oil_data_clean  : Primary source — all production columns surfaced
+                        downstream (e.g. well id, production volume,
+                        production date, field reference)
 */
 
 with base as (

--- a/dbt_projects/snowflake/models/staging/schema.yml
+++ b/dbt_projects/snowflake/models/staging/schema.yml
@@ -3,7 +3,7 @@ version: 2
 
 models:
   - name: snowflake_orders_staging
-    description: "A staging model for orders"
+    description: "Staging model joining snowflake_orders_clean to snowflake_customers_clean on the billing customer surrogate key. Filters out unshipped orders (ship_date IS NULL) and adds a SHA2 binary primary key derived from order_number."
     columns:
       - name: _pk
         description: "The primary key for this table"
@@ -13,8 +13,8 @@ models:
   - name: product_usage_staging
     config:
       tags:
-        - massive_dag 
-    description: "A staging model for orders"
+        - massive_dag
+    description: "Staging model exposing login / session activity from logins_clean. Upstream CTEs anchor dependencies on customers_clean, logins_clean, pipelines_clean, and tasks_clean to guarantee referenced product objects exist before downstream usage analytics run."
     columns:
       - name: vid
         description: "The primary key for this table"
@@ -24,10 +24,10 @@ models:
   - name: product_objects_staging
     config:
       tags:
-        - massive_dag 
+        - massive_dag
         - test_1
         - test_2
-    description: "A staging model for orders"
+    description: "Staging model surfacing login activity scoped to known product objects. CTEs validate availability of customers_clean, pipeline_runs_clean, task_runs_clean, and tasks_clean before selecting all rows from logins_clean."
     columns:
       - name: vid
         description: "The primary key for this table"
@@ -37,9 +37,9 @@ models:
   - name: marketing_data_staging
     config:
       tags:
-        - massive_dag 
+        - massive_dag
         - test_1
-    description: "A staging model for orders"
+    description: "Staging model that pass-through-surfaces Google Analytics marketing data from ga_data_clean. Upstream CTEs anchor a dependency on customers_clean so the customer dimension is guaranteed available before downstream attribution / reporting models consume the view."
     columns:
       - name: vid
         description: "The primary key for this table"


### PR DESCRIPTION
## Summary
- Fix copy-pasted docstrings on `oil_area_staging.sql` and `oil_production_staging.sql` (they previously referenced `marketing_data_staging` / `ga_data_clean`) with accurate descriptions of the oil-field area and oil production staging models.
- Replace the generic `"A staging model for orders"` descriptions in `schema.yml` with model-specific descriptions for `snowflake_orders_staging`, `product_usage_staging`, `product_objects_staging`, and `marketing_data_staging`.

## Test plan
- [ ] `dbt parse` succeeds against `dbt_projects/snowflake`
- [ ] `dbt docs generate` renders the updated model descriptions
- [ ] Visual diff review of the three changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)