### PR TITLE
Add docstring to oil_data_clean model

### DIFF
--- a/dbt_projects/snowflake/models/clean/oil_data_clean.sql
+++ b/dbt_projects/snowflake/models/clean/oil_data_clean.sql
@@ -1,3 +1,26 @@
+/*
+  Model: oil_data_clean
+  Description:
+    Cleans and augments raw oil-measurement data ingested via Fivetran.
+
+    Transformations applied:
+      - Selects all columns from the raw source so downstream consumers
+        continue to receive the full payload without explicit column wiring.
+      - Generates a deterministic surrogate primary key `_pk` by hashing
+        the concatenation of the event `timestamp` (cast to string) and
+        `site_name` with SHA-256 (sha2_binary). This makes per-site
+        time-series records uniquely identifiable for joins and
+        incremental merges.
+      - Adds a handful of static literal columns (`_test_column`,
+        `broken_column`, `_third_column`, `_fourth_column`) that are
+        used by downstream tests to exercise column-presence / schema-drift
+        behaviour. These are intentionally constant and should NOT be
+        treated as business data.
+
+  Source:  fivetran.oil_data
+  Grain:   one row per (site_name, timestamp) measurement
+  Output:  all raw columns plus _pk and four constant test columns
+*/
 select
 
 *,


### PR DESCRIPTION
## Summary
- Adds an explanatory header docstring to `dbt_projects/snowflake/models/clean/oil_data_clean.sql`, the only model in the `clean/` directory missing one.
- Documents the SHA-256 surrogate primary key, the source grain, and clarifies that the four constant string columns are intentional fixtures for downstream schema-drift tests (not real business data).
- All other models in `clean/` (and the `clean/snowflake/` subfolder) were inspected and already carried equivalent header blocks, so no changes were required there.

## Test plan
- [ ] `dbt parse` / `dbt compile` succeeds — the change is comment-only SQL and should not affect compilation.
- [ ] Visual review of the new header block for accuracy of the transformation description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)