### PR TITLE
docs(dbt/aggregated): fix and expand model docstrings

### DIFF
--- a/dbt_projects/snowflake/models/aggregated/marketing_data_aggregated.sql
+++ b/dbt_projects/snowflake/models/aggregated/marketing_data_aggregated.sql
@@ -1,27 +1,32 @@
 /*
   Model: marketing_data_aggregated
   Description:
-    Aggregated view combining marketing and customer data from multiple
-    upstream clean-layer sources. This model joins signals from customers,
-    logins, Google Analytics (GA) pipeline data, and seed data to provide
-    a unified marketing analytics surface.
+    Aggregated view intended to combine marketing and customer signals
+    across multiple clean-layer sources (customers, logins, Google
+    Analytics, seed/reference data).
 
-    The CTEs (base, logins, pipelines, tasks) are currently stub references
-    that select a literal 1 — they exist as scaffolding to formalise the
-    intended upstream dependencies. The actual aggregation logic and column
-    selection should be added here as requirements are clarified.
+    Current state: the model is wired up as a pure pass-through of
+    `ga_data_clean`. The four leading CTEs (`base`, `logins`, `pipelines`,
+    `tasks`) each `SELECT 1` from one of the upstream clean models — they
+    are not referenced in the final SELECT but force dbt to register
+    those tables as upstream dependencies in the DAG. This guarantees the
+    clean-layer build runs before this aggregate, which is useful both
+    for freshness and for keeping the lineage graph accurate while the
+    real join / aggregation logic is still being designed.
 
-    The final SELECT currently passes through all columns from `ga_data_clean`,
-    acting as a placeholder until the full join/aggregation logic is
-    implemented.
+    When the full marketing aggregation is implemented, the literal-1
+    CTEs should be replaced with real projections and joined into the
+    final SELECT (e.g. customer attribution onto GA events, login-based
+    engagement metrics, seeded campaign metadata).
 
   Sources:
-    - clean.customers_clean   (customer dimension — stub)
-    - clean.logins_clean      (login events — stub)
-    - clean.ga_data_clean     (Google Analytics marketing events — final output)
-    - clean.seed_clean        (seed/reference data — stub)
+    - clean.customers_clean   (customer dimension — dependency stub)
+    - clean.logins_clean      (login events — dependency stub)
+    - clean.ga_data_clean     (Google Analytics marketing events — primary source)
+    - clean.seed_clean        (seed / reference data — dependency stub)
+  Materialization: view (cheap to rebuild while logic evolves)
   Grain:   one row per GA event record (pass-through from ga_data_clean)
-  Output:  all columns from ga_data_clean
+  Output:  all columns from ga_data_clean (SELECT *)
 */
 {{ config(materialized='view') }}
 

--- a/dbt_projects/snowflake/models/aggregated/oil_data_aggregated.sql
+++ b/dbt_projects/snowflake/models/aggregated/oil_data_aggregated.sql
@@ -1,22 +1,28 @@
 {{ config(materialized='view') }}
 
 /*
-  Model: marketing_data_staging
+  Model: oil_data_aggregated
   Description:
-    Staging model that surfaces Google Analytics marketing data from the
-    ga_data_clean layer. The upstream CTE references (base, tasks) act as
-    dependency anchors, confirming that customer data is present and
-    consistent before the final output is produced.
+    Aggregated view over oil-field production measurement data. The model
+    selects a curated subset of columns from `oil_data_clean` and casts
+    the raw `timestamp` value into a proper TIMESTAMP type for downstream
+    time-series analysis.
 
-    All columns from ga_data_clean are passed through without transformation,
-    making this model the canonical staging source for marketing / web
-    analytics consumption in downstream reporting and attribution models.
+    The leading CTEs (`base`, `tasks`) are stub references that select a
+    literal 1 from `oil_area_staging` and `oil_production_staging`. They
+    are not used in the final SELECT but exist as explicit dependency
+    anchors so that dbt's DAG forces those upstream staging models to be
+    built / refreshed before this aggregate is materialised. Real join
+    or filter logic against those sources can be slotted in later
+    without having to re-introduce the references.
 
-  Upstream models:
-    - customers_clean : Validates customer dimension availability
-    - ga_data_clean   : Primary source — all GA marketing event columns
-                        surfaced downstream (e.g. sessions, conversions,
-                        traffic source, campaign data)
+  Sources:
+    - staging.oil_area_staging         (oil-field area metadata — dependency stub)
+    - staging.oil_production_staging   (production-side data — dependency stub)
+    - clean.oil_data_clean             (cleaned sensor / measurement events — primary source)
+  Grain:   one row per cleaned measurement record (pass-through from oil_data_clean)
+  Output:
+    site_name, owner, timestamp (TIMESTAMP), measurement, _fourth_column, _pk
 */
 
 with base as (

--- a/dbt_projects/snowflake/models/aggregated/snowflake_orders.sql
+++ b/dbt_projects/snowflake/models/aggregated/snowflake_orders.sql
@@ -2,36 +2,51 @@
   Model: snowflake_orders
   Description:
     Customer-level order summary table aggregated from `snowflake_orders_staging`.
-    Each row represents a unique combination of customer billing address,
-    shipping address, and ship date, with rolled-up order counts, quantities,
-    and costs.
+    Each row rolls up order counts, total quantity, and total cost for a
+    given customer (identified by name + email) shipping to a particular
+    (bill_customer_sk_id, ship_customer_sk_id, ship_date) combination.
 
     Key transformations applied:
-      - NULL-safe casting: bill_customer_sk_id and ship_customer_sk_id are cast
-        to STRING with IFNULL fallback to 'None', ensuring consistent GROUP BY
-        behaviour across nullable surrogate keys.
-      - Order deduplication: COUNT(DISTINCT order_number) is used to count
-        unique orders within each grouping, avoiding double-counting of line
-        items.
-      - Surrogate primary key (_pk): a SHA2-256 hash is computed over the
-        concatenation of bill_customer_sk_id, ship_customer_sk_id, and
-        ship_date to produce a stable, deterministic primary key for
-        downstream joins and incremental loads.
-      - Post-hook clone: after the table is built, a post-hook fires a clone
-        macro (clone()) to maintain a snapshot copy of the table.
+      - NULL-safe casting: bill_customer_sk_id and ship_customer_sk_id are
+        cast to STRING with IFNULL fallback to 'None'. This is required
+        because GROUP BY on a NULL surrogate key would otherwise collapse
+        every NULL row into the same bucket only inconsistently across
+        Snowflake versions / warehouses; coercing to the sentinel 'None'
+        gives a predictable grouping key.
+      - Order deduplication: COUNT(DISTINCT order_number) counts unique
+        orders within each grouping, so multi-line orders do not inflate
+        the order count.
+      - Surrogate primary key (_pk): SHA2_BINARY (SHA2-256) is computed
+        over the concatenation of bill_customer_sk_id, ship_customer_sk_id,
+        and ship_date — all NULL-coerced — to produce a stable,
+        deterministic key for downstream joins and incremental loads.
+        Note: because the GROUP BY also includes first_name / last_name /
+        email, the same _pk can in principle appear on more than one row
+        if a single shipping triple is associated with multiple customer
+        records — consumers expecting a unique key should be aware of this.
+      - Post-hook clone: after the table is built, the post-hook runs a
+        no-op `SELECT 1;` followed by the project's `clone()` macro,
+        which maintains a separate snapshot copy of the table for
+        recovery / audit purposes.
 
-    This model is materialised as a persistent (non-transient) table so that
-    the post-hook clone and downstream TIME TRAVEL queries work correctly.
+    The model is materialised as a persistent (transient=false) table so
+    that the cloned snapshot and any downstream TIME TRAVEL queries
+    against this object continue to work.
+
+    Note: the column name `bill_cutomer_sk_id` retains the upstream
+    typo (missing 's' in 'customer') for backward compatibility with
+    existing consumers; do not rename without coordinating downstream.
 
   Source:  staging.snowflake_orders_staging
-  Grain:   one row per (bill_customer_sk_id, ship_customer_sk_id, ship_date)
+  Grain:   one row per (first_name, last_name, email,
+                        bill_cutomer_sk_id, ship_customer_sk_id, ship_date)
   Output:
     first_name, last_name, email,
     bill_cutomer_sk_id, ship_customer_sk_id, ship_date,
-    orders  (count of distinct order numbers),
+    orders   (count of distinct order numbers),
     quantity (sum of line-item quantities),
-    cost    (sum of line-item costs),
-    _pk     (SHA2-256 surrogate key)
+    cost     (sum of line-item costs),
+    _pk      (SHA2-256 surrogate key over the shipping triple)
 */
 {{
     config(


### PR DESCRIPTION
## Summary
- Fixes the incorrect header docstring on `oil_data_aggregated.sql` — it currently identifies itself as `marketing_data_staging` and describes Google Analytics data, even though the model actually aggregates oil-field production measurements.
- Expands the docstring on `snowflake_orders.sql` to explain why nullable surrogate keys are coerced to `'None'` before grouping, what the `post_hook` (no-op `SELECT 1;` + project `clone()` macro) is doing, and why the column name retains the upstream `bill_cutomer_sk_id` typo. Also calls out a subtle grain caveat: because `first_name`/`last_name`/`email` are in the `GROUP BY` but not in the `_pk` hash, the surrogate key is not strictly unique.
- Tightens the docstring on `marketing_data_aggregated.sql` to make clear that the four `SELECT 1` CTEs are intentional dbt DAG dependency anchors (not dead code) and that the final SELECT is a deliberate pass-through until the real aggregation logic lands.

Docstrings only — no SQL behaviour changed.

## Test plan
- [ ] `dbt parse` succeeds for the snowflake project (no Jinja/SQL syntax regressions in the touched files).
- [ ] `dbt compile --select aggregated.*` produces identical compiled SQL on `main` vs this branch (diff should be comment-only).
- [ ] Spot-check the rendered docstrings in the file headers for accuracy against the actual `ref()` calls and final SELECT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)