### PR TITLE
feature - Add Slim CI workflow for dbt MotherDuck pipeline

### DIFF
--- a/.github/workflows/dbt_motherduck_slim_ci.yml
+++ b/.github/workflows/dbt_motherduck_slim_ci.yml
@@ -1,0 +1,40 @@
+name: dbt MotherDuck Slim CI
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'dbt_projects/motherduck_oil/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'dbt_projects/motherduck_oil/**'
+  workflow_dispatch:
+
+jobs:
+  quality-gates:
+    uses: ./.github/workflows/reusable-quality-gates.yml
+
+  dbt-slim-ci:
+    needs: quality-gates
+    runs-on: ubuntu-latest
+    environment: ${{ github.event_name == 'pull_request' && 'staging' || 'production' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run Orchestra pipeline (Slim CI)
+        uses: orchestra-hq/run-pipeline@v1
+        with:
+          api_key: ${{ secrets.ORCHESTRA_API_KEY }}
+          pipeline_id: 73411213-9808-4fe4-802d-ba1da8c11a90
+          poll_interval: 20
+          environment: ${{ github.event_name == 'pull_request' && 'Staging' || 'Production' }}
+          task_ids: 07628741-c100-43c2-91d2-54b9ca5d4fe2
+          run_inputs: |
+            {
+              "dbt_command": "build -s state:modified+ --defer --state latest_production --target ${{ github.event_name == 'pull_request' && 'ci' || 'prod' }}",
+              "dbt_branch": "${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
+            }

--- a/dbt_projects/motherduck_oil/profiles.yml.example
+++ b/dbt_projects/motherduck_oil/profiles.yml.example
@@ -5,3 +5,11 @@ motherduck:
       type: duckdb
       path: md:your_database
       schema: motherduck_oil
+    ci:
+      type: duckdb
+      path: md:your_database
+      schema: "ci_{{ env_var('DBT_CI_SCHEMA_SUFFIX', 'pr') }}"
+    prod:
+      type: duckdb
+      path: md:your_database
+      schema: motherduck_oil


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/dbt_motherduck_slim_ci.yml` that calls Orchestra pipeline `dbt MotherDuck ELT` (`73411213-9808-4fe4-802d-ba1da8c11a90`) on PRs and merges touching `dbt_projects/motherduck_oil/**`. PRs run as Orchestra env `Staging`; merges run as `Production`.
- Filters to only the dbt Build task (`task_ids: 07628741-c100-43c2-91d2-54b9ca5d4fe2`) so the Python ingest task is skipped on CI.
- Adds `ci` and `prod` outputs to `profiles.yml.example` for `motherduck_oil` so contributors see the targets Slim CI expects.

## Required before merging — Orchestra UI changes
Pipeline `73411213-9808-4fe4-802d-ba1da8c11a90` is Orchestra-backed (no YAML in this repo), so these must be applied in the UI:

1. **Pipeline → Inputs**
   - `dbt_branch` · type: string · default: `main`
   - `dbt_command` · type: string · default: `build`
2. **dbt Build task → Parameters**
   - `commands`: `dbt \${{ inputs.dbt_command }}`
   - `branch`: `\${{ inputs.dbt_branch }}`
3. **dbt connection `dbt_motherduck__prod__39243`**
   - Update uploaded `profiles.yml` with `ci` and `prod` outputs matching `profiles.yml.example` (a successful prod run on `main` at 2026-05-26 13:27 already exists → `latest_production` baseline ready).

## Required GitHub config
- `ORCHESTRA_API_KEY` secret on `staging` and `production` environments (or repo-level if shared with the existing `orchestra_trigger.yaml`).

## Test plan
- [ ] Apply the three Orchestra UI changes above
- [ ] Open a PR touching \`dbt_projects/motherduck_oil/models/**\` and confirm \`dbt MotherDuck Slim CI / dbt-slim-ci\` check runs against \`Staging\` with \`--target ci --defer --state latest_production\`
- [ ] Confirm Orchestra run link appears in the action log and run uses the PR head branch for dbt checkout
- [ ] Merge a no-op change to \`main\` and confirm the workflow re-runs against \`Production\` with \`--target prod\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)