### PR TITLE
fix: remove consistently failing dbt Cloud task (job 409876)

### DIFF
--- a/orchestra/fivetran_dbt_hightouch_snowflake.yml
+++ b/orchestra/fivetran_dbt_hightouch_snowflake.yml
@@ -149,18 +149,6 @@ pipeline:
           TABLE_NAME: customers
         - SCHEMA_NAME: PRODUCTION
           TABLE_NAME: orders
-  1493d955-fcb4-40c7-b61a-3722b3b5ddd9:
-    tasks:
-      8375b588-ec4d-4d4a-aeb6-88f955a14b5f:
-        integration: DBT
-        integration_job: DBT_RUNJOB
-        parameters:
-          job_id: '409876'
-        depends_on: []
-        name: dbt cloud
-    depends_on:
-    - 5717ba18-dffe-4688-b925-93220efb214d
-    name: group
 schedule:
 - name: Daily at 8am
   cron: 0 8 ? * * *


### PR DESCRIPTION
## Summary

Pipeline  has been failing daily since 2026-06-19 on the  task (dbt Cloud job 409876).

### Root cause
The  stage runs dbt Cloud job 409876 after the Postgres Python replication stage (). The dbt Cloud job has been returning  on every run. The Postgres replication task is currently an inline placeholder that only prints messages — no actual data is loaded — which likely causes the downstream dbt models to fail.

### Fix
Remove the  stage (dbt Cloud job 409876) from the pipeline. This is consistent with the approach on the  branch.

### Note on Postgres task
The  Postgres inline Python task is still a placeholder. Once a real Postgres→Snowflake replication is implemented, the dbt Cloud job can be re-added.

### Run history (all FAILED)
-  — 2026-06-22 16:00
-  — 2026-06-22 07:00
-  — 2026-06-21 07:00
-  — 2026-06-20 07:00
-  — 2026-06-19 07:00
