### PR TITLE
Fix justdbt pipeline: add missing project_dir

### DIFF
--- a/orchestra/pleasedeleteme.yml
+++ b/orchestra/pleasedeleteme.yml
@@ -9,6 +9,7 @@ pipeline:
         parameters:
           commands: dbt build;
           package_manager: PIP
+          project_dir: dbt_projects/snowflake
           python_version: '3.12'
         depends_on: []
         name: dbt build


### PR DESCRIPTION
The `dbt build` task in `orchestra/pleasedeleteme.yml` was missing `project_dir`, so it ran at repo root and failed with `requirements.txt file not found` (hourly schedule failing). This restores `project_dir: dbt_projects/snowflake`, matching the last successful run.