### PR TITLE
Add Google Sheet ingest pipeline (dlt + parallel non-dlt task)

### DIFF
--- a/orchestra/google_sheet_dlt_simple.yml
+++ b/orchestra/google_sheet_dlt_simple.yml
@@ -1,0 +1,26 @@
+version: v1
+name: 'Google Sheet DLT Ingest #dlt #python #bigquery'
+pipeline:
+  76111440-4c94-4712-8b66-93c2a3ff6677:
+    tasks:
+      7dc7b4eb-2953-440e-a025-301bf1998caa:
+        integration: PYTHON
+        integration_job: PYTHON_EXECUTE_SCRIPT
+        parameters:
+          package_manager: PIP
+          python_version: '3.12'
+          build_command: pip install -r requirements.txt
+          environment_variables: '{
+            "SHEET_NAME": "1r6OykF-UAGR-IOn1WjVORCf7PiqA5f5USDT6kMoTGmM",
+            "TABLE_NAME": "new_sheet_data"
+            }'
+          set_outputs: false
+          source: GIT
+          command: python -m google_sheet_ingest
+          project_dir: python/dlt
+          shallow_clone_dirs: python/dlt
+        depends_on: []
+        name: Run Google Sheet dlt pipeline
+        connection: python__production__blueprints__19239
+    depends_on: []
+    name: ''

--- a/orchestra/google_sheet_dlt_simple.yml
+++ b/orchestra/google_sheet_dlt_simple.yml
@@ -10,18 +10,18 @@ pipeline:
           package_manager: PIP
           python_version: '3.12'
           build_command: pip install -r requirements.txt
-          environment_variables: '{
-            "SHEET_NAME": "1r6OykF-UAGR-IOn1WjVORCf7PiqA5f5USDT6kMoTGmM",
-            "TABLE_NAME": "new_sheet_data"
-            }'
+          environment_variables: '{ "SHEET_NAME": "1r6OykF-UAGR-IOn1WjVORCf7PiqA5f5USDT6kMoTGmM",
+            "TABLE_NAME": "new_sheet_data" }'
           set_outputs: false
           source: GIT
-          branch: add-google-sheet-dlt-pipeline
           command: python -m google_sheet_ingest
+          branch: add-google-sheet-dlt-pipeline
           project_dir: python/dlt
           shallow_clone_dirs: python/dlt
         depends_on: []
         name: Run Google Sheet dlt pipeline
-        connection: python__production__blueprints__19239
+        connection: ${{ ENV.PYTHON_CREDENTIAL }}
     depends_on: []
     name: ''
+webhook:
+  enabled: false

--- a/orchestra/google_sheet_dlt_simple.yml
+++ b/orchestra/google_sheet_dlt_simple.yml
@@ -16,6 +16,7 @@ pipeline:
             }'
           set_outputs: false
           source: GIT
+          branch: add-google-sheet-dlt-pipeline
           command: python -m google_sheet_ingest
           project_dir: python/dlt
           shallow_clone_dirs: python/dlt

--- a/orchestra/google_sheet_dlt_simple.yml
+++ b/orchestra/google_sheet_dlt_simple.yml
@@ -21,6 +21,26 @@ pipeline:
         depends_on: []
         name: Run Google Sheet dlt pipeline
         connection: ${{ ENV.PYTHON_CREDENTIAL }}
+      d0db33f3-8c21-4bab-9f9c-74fb99239fd7:
+        integration: PYTHON
+        integration_job: PYTHON_EXECUTE_SCRIPT
+        parameters:
+          package_manager: PIP
+          python_version: '3.12'
+          build_command: pip install -r requirements.txt
+          environment_variables: '{
+            "SHEET_NAME": "1r6OykF-UAGR-IOn1WjVORCf7PiqA5f5USDT6kMoTGmM",
+            "TABLE_NAME": "new_sheet_data_native"
+            }'
+          set_outputs: false
+          source: GIT
+          branch: add-google-sheet-dlt-pipeline
+          command: python -m google_sheet_ingest
+          project_dir: python/google_sheets_native
+          shallow_clone_dirs: python/google_sheets_native
+        depends_on: []
+        name: Run Google Sheet ingest without dlt
+        connection: ${{ ENV.PYTHON_CREDENTIAL }}
     depends_on: []
     name: ''
 webhook:

--- a/python/dlt/google_sheet_ingest.py
+++ b/python/dlt/google_sheet_ingest.py
@@ -1,0 +1,8 @@
+import os
+
+from google_sheets_pipeline import run_google_sheets_pipeline
+
+run_google_sheets_pipeline(
+    os.environ["SHEET_NAME"],
+    table_name=os.environ.get("TABLE_NAME", "new_sheet_data"),
+)

--- a/python/google_sheets_native/google_sheet_ingest.py
+++ b/python/google_sheets_native/google_sheet_ingest.py
@@ -1,0 +1,56 @@
+import os
+
+import google.auth
+from google.cloud import bigquery
+from googleapiclient.discovery import build
+
+SCOPES = [
+    "https://www.googleapis.com/auth/spreadsheets.readonly",
+    "https://www.googleapis.com/auth/bigquery",
+]
+
+
+def run_google_sheets_ingest(
+    spreadsheet_id: str,
+    range_name: str,
+    dataset_name: str,
+    table_name: str,
+) -> None:
+    """Reads a range from a Google Sheet and loads it straight into BigQuery, no dlt involved."""
+    credentials, project_id = google.auth.default(scopes=SCOPES)
+
+    sheets_service = build("sheets", "v4", credentials=credentials)
+    values = (
+        sheets_service.spreadsheets()
+        .values()
+        .get(spreadsheetId=spreadsheet_id, range=range_name)
+        .execute()
+        .get("values", [])
+    )
+    if not values:
+        print(f"Range {range_name} returned no data. Nothing to load.")
+        return
+
+    headers, *rows = values
+    records = [dict(zip(headers, row)) for row in rows]
+
+    bq_client = bigquery.Client(credentials=credentials, project=project_id)
+    table_id = f"{project_id}.{dataset_name}.{table_name}"
+    job = bq_client.load_table_from_json(
+        records,
+        table_id,
+        job_config=bigquery.LoadJobConfig(
+            write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+            autodetect=True,
+        ),
+    )
+    job.result()
+    print(f"Loaded {len(records)} rows into {table_id}")
+
+
+run_google_sheets_ingest(
+    os.environ["SHEET_NAME"],
+    range_name=os.environ.get("RANGE_NAME", "dlt_range"),
+    dataset_name=os.environ.get("DATASET_NAME", "sample_google_sheet_data"),
+    table_name=os.environ.get("TABLE_NAME", "new_sheet_data_native"),
+)

--- a/python/google_sheets_native/google_sheet_ingest.py
+++ b/python/google_sheets_native/google_sheet_ingest.py
@@ -1,25 +1,21 @@
 import os
 
-print(
-    "DEBUG env keys:",
-    sorted(
-        k
-        for k in os.environ
-        if any(
-            s in k.upper()
-            for s in ["CRED", "GOOGLE", "GCP", "BIGQUERY", "SERVICE_ACCOUNT"]
-        )
-    ),
-)
-
-import google.auth
 from google.cloud import bigquery
+from google.oauth2 import service_account
 from googleapiclient.discovery import build
 
-SCOPES = [
-    "https://www.googleapis.com/auth/spreadsheets.readonly",
-    "https://www.googleapis.com/auth/bigquery",
-]
+SHEETS_SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
+
+
+def _service_account_credentials(env_prefix: str, scopes: list) -> service_account.Credentials:
+    info = {
+        "type": "service_account",
+        "project_id": os.environ[f"{env_prefix}__PROJECT_ID"],
+        "client_email": os.environ[f"{env_prefix}__CLIENT_EMAIL"],
+        "private_key": os.environ[f"{env_prefix}__PRIVATE_KEY"],
+        "token_uri": "https://oauth2.googleapis.com/token",
+    }
+    return service_account.Credentials.from_service_account_info(info, scopes=scopes)
 
 
 def run_google_sheets_ingest(
@@ -29,9 +25,15 @@ def run_google_sheets_ingest(
     table_name: str,
 ) -> None:
     """Reads a range from a Google Sheet and loads it straight into BigQuery, no dlt involved."""
-    credentials, project_id = google.auth.default(scopes=SCOPES)
+    sheets_credentials = _service_account_credentials(
+        "SOURCES__GOOGLE_SHEETS__CREDENTIALS", SHEETS_SCOPES
+    )
+    bigquery_credentials = _service_account_credentials(
+        "DESTINATION__BIGQUERY__CREDENTIALS", []
+    )
+    project_id = bigquery_credentials.project_id
 
-    sheets_service = build("sheets", "v4", credentials=credentials)
+    sheets_service = build("sheets", "v4", credentials=sheets_credentials)
     values = (
         sheets_service.spreadsheets()
         .values()
@@ -46,7 +48,11 @@ def run_google_sheets_ingest(
     headers, *rows = values
     records = [dict(zip(headers, row)) for row in rows]
 
-    bq_client = bigquery.Client(credentials=credentials, project=project_id)
+    bq_client = bigquery.Client(
+        credentials=bigquery_credentials,
+        project=project_id,
+        location=os.environ.get("DESTINATION__BIGQUERY__LOCATION"),
+    )
     table_id = f"{project_id}.{dataset_name}.{table_name}"
     job = bq_client.load_table_from_json(
         records,

--- a/python/google_sheets_native/google_sheet_ingest.py
+++ b/python/google_sheets_native/google_sheet_ingest.py
@@ -1,5 +1,17 @@
 import os
 
+print(
+    "DEBUG env keys:",
+    sorted(
+        k
+        for k in os.environ
+        if any(
+            s in k.upper()
+            for s in ["CRED", "GOOGLE", "GCP", "BIGQUERY", "SERVICE_ACCOUNT"]
+        )
+    ),
+)
+
 import google.auth
 from google.cloud import bigquery
 from googleapiclient.discovery import build

--- a/python/google_sheets_native/requirements.txt
+++ b/python/google_sheets_native/requirements.txt
@@ -1,0 +1,4 @@
+orchestra-sdk==0.1.2
+google-api-python-client==2.182.0
+google-cloud-bigquery==3.27.0
+google-auth==2.35.0


### PR DESCRIPTION
## Summary
- Adds a Google Sheet ingest pipeline (`orchestra/google_sheet_dlt_simple.yml`) with a dlt-based Python task loading into `sample_google_sheet_data.new_sheet_data`.
- Adds a parallel, non-dlt Python task (`python/google_sheets_native/`) that reads the same named range via the Sheets API directly and loads into `sample_google_sheet_data.new_sheet_data_native` via `google-cloud-bigquery`, using service account credentials built from the connection's injected env vars.

## Test plan
- [x] `orchestra-cli validate` passes on the pipeline YAML
- [x] Ran the full pipeline on this branch — both tasks succeeded in parallel (https://app.getorchestra.io/pipeline-runs/e0047ece-4992-47e9-81bb-794657e698ef/lineage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)