### PR TITLE
Point Google Sheet pipeline tasks at main

### DIFF
--- a/orchestra/google_sheet_dlt_simple.yml
+++ b/orchestra/google_sheet_dlt_simple.yml
@@ -15,7 +15,7 @@ pipeline:
           set_outputs: false
           source: GIT
           command: python -m google_sheet_ingest
-          branch: add-google-sheet-dlt-pipeline
+          branch: main
           project_dir: python/dlt
           shallow_clone_dirs: python/dlt
         depends_on: []
@@ -34,7 +34,7 @@ pipeline:
             }'
           set_outputs: false
           source: GIT
-          branch: add-google-sheet-dlt-pipeline
+          branch: main
           command: python -m google_sheet_ingest
           project_dir: python/google_sheets_native
           shallow_clone_dirs: python/google_sheets_native


### PR DESCRIPTION
## Summary
- Both tasks in `orchestra/google_sheet_dlt_simple.yml` were pinned to `branch: add-google-sheet-dlt-pipeline` for the git source. Now that pipeline is merged into main, point both at `branch: main` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)