### PR TITLE
Fix dlt Google Sheets ingest row mismatch + add BigQuery reconciliation pipeline

### DIFF
--- a/orchestra/google_sheet_dlt_simple.yml
+++ b/orchestra/google_sheet_dlt_simple.yml
@@ -15,7 +15,7 @@ pipeline:
           set_outputs: false
           source: GIT
           command: python -m google_sheet_ingest
-          branch: compare-gsheet-dlt-native-datasets
+          branch: main
           project_dir: python/dlt
           shallow_clone_dirs: python/dlt
         depends_on: []

--- a/orchestra/google_sheet_dlt_simple.yml
+++ b/orchestra/google_sheet_dlt_simple.yml
@@ -15,7 +15,7 @@ pipeline:
           set_outputs: false
           source: GIT
           command: python -m google_sheet_ingest
-          branch: main
+          branch: compare-gsheet-dlt-native-datasets
           project_dir: python/dlt
           shallow_clone_dirs: python/dlt
         depends_on: []

--- a/orchestra/google_sheet_dlt_vs_native_reconciliation.yml
+++ b/orchestra/google_sheet_dlt_vs_native_reconciliation.yml
@@ -1,0 +1,72 @@
+version: v1
+name: 'Google Sheet DLT vs Native Reconciliation #bigquery #data-reconciliation #dq'
+pipeline:
+  row_count_parity:
+    tasks:
+      check_row_count_parity:
+        integration: GCP_BIG_QUERY
+        integration_job: GCP_BQ_RUN_TEST
+        parameters:
+          query: >
+            select 1 from
+            (select count(*) as cnt from `${{ MATRIX.table_checks['dataset'] }}.${{ MATRIX.table_checks['dlt_table'] }}`) as dlt,
+            (select count(*) as cnt from `${{ MATRIX.table_checks['dataset'] }}.${{ MATRIX.table_checks['native_table'] }}`) as native
+            where dlt.cnt != native.cnt
+          enable_drive_scope: false
+          location: US
+          error_threshold_expression: '> 0'
+          warn_threshold_expression: '> 0'
+        depends_on: []
+        name: "Row count parity - ${{ MATRIX.table_checks['label'] }}"
+        connection: dbt_bigquery_24777
+    depends_on: []
+    name: 'Row Count Parity'
+    matrix:
+      inputs:
+        table_checks:
+        - label: 'new_sheet_data (dlt) vs new_sheet_data_native (non-dlt)'
+          dataset: sample_google_sheet_data
+          dlt_table: new_sheet_data
+          native_table: new_sheet_data_native
+  content_parity:
+    tasks:
+      check_content_parity:
+        integration: GCP_BIG_QUERY
+        integration_job: GCP_BQ_RUN_TEST
+        parameters:
+          # Only the columns both ingestion methods actually carry are compared -- the dlt
+          # table also has _dlt_load_id/_dlt_id lineage columns and named-range metadata
+          # (spreadsheet_id, title, range_name, range_parsed__*, skipped) that the native
+          # loader doesn't produce, so those are out of scope for this check.
+          # bit_xor (not sum) over farm_fingerprint avoids INT64 overflow on the hash aggregate.
+          query: >
+            select 1 from
+            (select bit_xor(farm_fingerprint(concat(cast(site_name as string), '|', cast(measurement as string), '|', cast(owner as string), '|', cast(unix_seconds(timestamp) as string)))) as chk
+             from `${{ MATRIX.table_checks['dataset'] }}.${{ MATRIX.table_checks['dlt_table'] }}`) as dlt,
+            (select bit_xor(farm_fingerprint(concat(cast(site_name as string), '|', cast(measurement as string), '|', cast(owner as string), '|', cast(unix_seconds(timestamp) as string)))) as chk
+             from `${{ MATRIX.table_checks['dataset'] }}.${{ MATRIX.table_checks['native_table'] }}`) as native
+            where dlt.chk != native.chk
+          enable_drive_scope: false
+          location: US
+          error_threshold_expression: '> 0'
+          warn_threshold_expression: '> 0'
+        depends_on: []
+        name: "Content parity (site_name, measurement, owner, timestamp) - ${{ MATRIX.table_checks['label'] }}"
+        connection: dbt_bigquery_24777
+    depends_on:
+    - row_count_parity
+    condition: ${{ task_groups['row_count_parity'].all().status == 'COMPLETED' }}
+    name: 'Content Parity'
+    matrix:
+      inputs:
+        table_checks:
+        - label: 'new_sheet_data (dlt) vs new_sheet_data_native (non-dlt)'
+          dataset: sample_google_sheet_data
+          dlt_table: new_sheet_data
+          native_table: new_sheet_data_native
+alerts:
+- name: Reconciliation Failure
+  statuses: [FAILED, WARNING]
+  destinations:
+  - integration: SLACK
+    destination: alert-demos

--- a/python/dlt/google_sheets_pipeline.py
+++ b/python/dlt/google_sheets_pipeline.py
@@ -2,28 +2,6 @@ import dlt
 
 from google_sheets import google_spreadsheet
 
-# Columns the google_sheets source attaches to every row regardless of its actual
-# sheet content -- a row with real data in none of the *other* columns is a phantom
-# blank row (e.g. a trailing empty row still inside the named range's bounds, which
-# the Sheets API itself would otherwise trim).
-_RANGE_METADATA_KEYS = {
-    "spreadsheet_id",
-    "title",
-    "range_name",
-    "range",
-    "range_parsed",
-    "skipped",
-}
-
-
-def _has_data(row: dict) -> bool:
-    print("DEBUG_ROW:", repr(row))
-    return any(
-        value not in (None, "")
-        for key, value in row.items()
-        if key not in _RANGE_METADATA_KEYS
-    )
-
 
 def load_pipeline_with_named_ranges(
     spreadsheet_url_or_id: str,
@@ -45,9 +23,12 @@ def load_pipeline_with_named_ranges(
         get_sheets=False,
         get_named_ranges=True,
     )
-    for resource_name, resource in data.resources.items():
-        if resource_name != "spreadsheet_info":
-            resource.add_filter(_has_data)
+    # Only load the named-range data resource(s) -- "spreadsheet_info" is sheet-level
+    # metadata with no data columns of its own. Passing table_name=table_name below
+    # forces every selected resource into one table, so leaving spreadsheet_info
+    # selected would union its metadata-only row into the data table as a phantom
+    # all-null record.
+    data = data.with_resources(*(r for r in data.resources if r != "spreadsheet_info"))
     print(table_name)
     info = pipeline.run(data, table_name=table_name, write_disposition="replace")
     print(info)

--- a/python/dlt/google_sheets_pipeline.py
+++ b/python/dlt/google_sheets_pipeline.py
@@ -44,7 +44,9 @@ def load_pipeline_with_named_ranges(
         get_sheets=False,
         get_named_ranges=True,
     )
-    data = data.add_filter(_has_data)
+    for resource_name, resource in data.resources.items():
+        if resource_name != "spreadsheet_info":
+            resource.add_filter(_has_data)
     print(table_name)
     info = pipeline.run(data, table_name=table_name, write_disposition="replace")
     print(info)

--- a/python/dlt/google_sheets_pipeline.py
+++ b/python/dlt/google_sheets_pipeline.py
@@ -2,6 +2,27 @@ import dlt
 
 from google_sheets import google_spreadsheet
 
+# Columns the google_sheets source attaches to every row regardless of its actual
+# sheet content -- a row with real data in none of the *other* columns is a phantom
+# blank row (e.g. a trailing empty row still inside the named range's bounds, which
+# the Sheets API itself would otherwise trim).
+_RANGE_METADATA_KEYS = {
+    "spreadsheet_id",
+    "title",
+    "range_name",
+    "range",
+    "range_parsed",
+    "skipped",
+}
+
+
+def _has_data(row: dict) -> bool:
+    return any(
+        value not in (None, "")
+        for key, value in row.items()
+        if key not in _RANGE_METADATA_KEYS
+    )
+
 
 def load_pipeline_with_named_ranges(
     spreadsheet_url_or_id: str,
@@ -23,6 +44,7 @@ def load_pipeline_with_named_ranges(
         get_sheets=False,
         get_named_ranges=True,
     )
+    data = data.add_filter(_has_data)
     print(table_name)
     info = pipeline.run(data, table_name=table_name, write_disposition="replace")
     print(info)

--- a/python/dlt/google_sheets_pipeline.py
+++ b/python/dlt/google_sheets_pipeline.py
@@ -17,6 +17,7 @@ _RANGE_METADATA_KEYS = {
 
 
 def _has_data(row: dict) -> bool:
+    print("DEBUG_ROW:", repr(row))
     return any(
         value not in (None, "")
         for key, value in row.items()

--- a/python/dlt/google_sheets_pipeline.py
+++ b/python/dlt/google_sheets_pipeline.py
@@ -24,7 +24,7 @@ def load_pipeline_with_named_ranges(
         get_named_ranges=True,
     )
     print(table_name)
-    info = pipeline.run(data, table_name=table_name)
+    info = pipeline.run(data, table_name=table_name, write_disposition="replace")
     print(info)
 
 


### PR DESCRIPTION
## Summary
- Adds `orchestra/google_sheet_dlt_vs_native_reconciliation.yml`, an Orchestra reconciliation pipeline comparing the dlt-loaded `new_sheet_data` table against the non-dlt `new_sheet_data_native` table (row count + content hash on shared columns).
- Fixes two real bugs in `python/dlt/google_sheets_pipeline.py` found while building/running that reconciliation pipeline:
  - `pipeline.run()` had no `write_disposition`, so dlt defaulted to `append` — every pipeline run added on top of the last instead of refreshing. Fixed with `write_disposition="replace"`.
  - `pipeline.run(data, table_name=table_name, ...)` forced *every* resource in the `google_spreadsheet()` source into one table, so the `spreadsheet_info` metadata-only resource's single row was getting unioned into `new_sheet_data` as a phantom all-null record (this, not accumulation, was the actual cause of the row-count mismatch against the native loader). Fixed by selecting only the real data resource(s) before loading.

## Test plan
- [x] Ran the ingest pipeline on a feature branch after each fix and re-ran the reconciliation pipeline until both the row-count and content-parity checks passed (79 rows, matching content, in both tables).
- [x] `validate_pipeline` passed on the reconciliation YAML.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>