### PR TITLE
Add Meltano tap-hubspot -> target-bigquery project and pipeline

### DIFF
--- a/meltano/.env.example
+++ b/meltano/.env.example
@@ -1,0 +1,13 @@
+# Copy to .env and fill in real values. Never commit the real .env file.
+
+# tap-hubspot
+TAP_HUBSPOT_ACCESS_TOKEN=your-hubspot-private-app-token
+
+# target-bigquery
+BIGQUERY_PROJECT=your-gcp-project-id
+BIGQUERY_DATASET=hubspot
+BIGQUERY_LOCATION=US
+
+# Path to a service account JSON key with BigQuery permissions.
+# Alternatively rely on Application Default Credentials and omit this.
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json

--- a/meltano/.gitignore
+++ b/meltano/.gitignore
@@ -1,0 +1,5 @@
+.env
+.meltano/
+logs/
+output/
+*.log

--- a/meltano/README.md
+++ b/meltano/README.md
@@ -1,0 +1,33 @@
+# Meltano: tap-hubspot -> target-bigquery
+
+Minimal Meltano project that extracts data from HubSpot and loads it into
+BigQuery.
+
+## Setup
+
+```bash
+cd meltano
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+
+cp .env.example .env   # then fill in your HubSpot token and GCP project/dataset
+
+meltano install
+```
+
+## Run
+
+```bash
+meltano run tap-hubspot target-bigquery
+```
+
+## Notes
+
+- `TAP_HUBSPOT_ACCESS_TOKEN` must be a HubSpot private app access token.
+- `BIGQUERY_PROJECT` / `BIGQUERY_DATASET` control where data lands; the
+  dataset is created automatically if it doesn't exist.
+- Auth to GCP uses `GOOGLE_APPLICATION_CREDENTIALS` (a service account key)
+  or Application Default Credentials (`gcloud auth application-default login`)
+  if that variable is left unset.
+- `select: ["*.*"]` in `meltano.yml` pulls every stream/field tap-hubspot
+  exposes; narrow this once you know which HubSpot objects you need.

--- a/meltano/meltano.yml
+++ b/meltano/meltano.yml
@@ -1,0 +1,24 @@
+version: 1
+default_environment: dev
+project_id: orchestra-blueprints-hubspot-bigquery
+environments:
+  - name: dev
+plugins:
+  extractors:
+    - name: tap-hubspot
+      variant: meltanolabs
+      pip_url: git+https://github.com/MeltanoLabs/tap-hubspot.git
+      config:
+        start_date: '2020-01-01T00:00:00Z'
+      select:
+        - "*.*"
+
+  loaders:
+    - name: target-bigquery
+      variant: z3z1ma
+      pip_url: target-bigquery
+      config:
+        project: $BIGQUERY_PROJECT
+        dataset: $BIGQUERY_DATASET
+        location: $BIGQUERY_LOCATION
+        method: batch_job

--- a/meltano/requirements.txt
+++ b/meltano/requirements.txt
@@ -1,0 +1,1 @@
+meltano

--- a/orchestra/meltano_hubspot_bigquery.yml
+++ b/orchestra/meltano_hubspot_bigquery.yml
@@ -1,0 +1,30 @@
+version: v1
+name: 'Meltano HubSpot to BigQuery #meltano #hubspot #bigquery #python'
+pipeline:
+  4a1e6c2f-8d3b-4f7a-9c5e-2b6d8f1a3c07:
+    tasks:
+      7b3f9e2a-5c1d-4a8f-b6e3-9d2c7a4f1b08:
+        integration: PYTHON
+        integration_job: PYTHON_EXECUTE_SCRIPT
+        parameters:
+          package_manager: PIP
+          python_version: '3.12'
+          build_command: pip install -r requirements.txt && meltano install
+          environment_variables: '{
+            "TAP_HUBSPOT_ACCESS_TOKEN": "${{ ENV.TAP_HUBSPOT_ACCESS_TOKEN }}",
+            "BIGQUERY_PROJECT": "${{ ENV.BIGQUERY_PROJECT }}",
+            "BIGQUERY_DATASET": "${{ ENV.BIGQUERY_DATASET }}",
+            "BIGQUERY_LOCATION": "${{ ENV.BIGQUERY_LOCATION }}"
+            }'
+          set_outputs: false
+          source: GIT
+          command: python -m meltano run tap-hubspot target-bigquery
+          project_dir: meltano
+          shallow_clone_dirs: meltano
+        depends_on: []
+        name: Meltano - tap-hubspot to target-bigquery
+        connection: python__production__blueprints__19239
+    depends_on: []
+    name: ''
+webhook:
+  enabled: false


### PR DESCRIPTION
## Summary
- Adds `meltano/`: a minimal Meltano project running `tap-hubspot` (MeltanoLabs variant) into `target-bigquery` (z3z1ma variant), with `.env.example`, `requirements.txt`, and a README.
- Adds `orchestra/meltano_hubspot_bigquery.yml`: an Orchestra pipeline that runs the project via a `PYTHON` task (`meltano install` then `meltano run tap-hubspot target-bigquery`), using the existing default `python__production__blueprints__19239` connection, consistent with `orchestra/google_sheet_dlt_simple.yml`.

## Validation
Validated live against Orchestra's pipeline schema validator (`validate_pipeline`) — passed on first attempt.

## Manual follow-ups
- `TAP_HUBSPOT_ACCESS_TOKEN`, `BIGQUERY_PROJECT`, `BIGQUERY_DATASET`, `BIGQUERY_LOCATION` are referenced via `${{ ENV.* }}` in the task's `environment_variables` — these must be configured as environment variables in the Orchestra workspace before the pipeline can run successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)