### PR TITLE
Point tap-lightdash meltano extractor at fixed fork

### DIFF
--- a/python/meltano/meltano.yml
+++ b/python/meltano/meltano.yml
@@ -7,7 +7,7 @@ plugins:
   extractors:
     - name: tap-lightdash
       variant: gthesheep
-      pip_url: git+https://github.com/gthesheep/tap-lightdash.git
+      pip_url: git+https://github.com/gthesheep-orchestra/tap-lightdash.git
       config:
         url: $TAP_LIGHTDASH_URL
         personal_access_token: $TAP_LIGHTDASH_PERSONAL_ACCESS_TOKEN


### PR DESCRIPTION
The Meltano Lightdash → BigQuery pipeline was failing during install:

```
ModuleNotFoundError: No module named 'distutils'
hint: `pendulum` (v2.1.2) was included because `tap-lightdash` (v0.0.1)
depends on `singer-sdk` (v0.8.0) which depends on `pendulum`
```

`singer-sdk` 0.8.0 pins `pendulum<3.0.0`, and pendulum 2.1.2's sdist build
fails on Python 3.12 (`distutils` was removed).

Fixed upstream in [gthesheep-orchestra/tap-lightdash#1](https://github.com/gthesheep-orchestra/tap-lightdash/pull/1)
(bumped `singer-sdk` to `>=0.40,<1`, which has no pendulum dependency).
This PR points the `tap-lightdash` extractor's `pip_url` at that fixed
fork so the pipeline installs the working version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)