### PR TITLE
Fix meltano invocation in Lightdash-to-BigQuery pipeline task

### DIFF
--- a/orchestra/meltano_lightdash_bigquery.yml
+++ b/orchestra/meltano_lightdash_bigquery.yml
@@ -12,7 +12,7 @@ pipeline:
           build_command: pip install -r requirements.txt && meltano install
           set_outputs: false
           source: GIT
-          command: python -m meltano run tap-lightdash target-bigquery
+          command: meltano run tap-lightdash target-bigquery
           project_dir: python/meltano
           shallow_clone_dirs: python/meltano
         depends_on: []


### PR DESCRIPTION
## Problem

The Meltano → BigQuery task failed with:

```
No module named meltano.__main__; 'meltano' is a package and cannot
be directly executed
```

The `meltano` package doesn't ship a `__main__.py`, so `python -m
meltano ...` never works — it only exposes a `meltano` console-script
entry point.

## Fix

Use the console script directly: `meltano run tap-lightdash
target-bigquery`.

Found this while validating the tap-lightdash pendulum/singer-sdk fix
(#250) end-to-end through the actual pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)