### PR TITLE
Invoke meltano via python -m meltano.cli

### DIFF
--- a/orchestra/meltano_lightdash_bigquery.yml
+++ b/orchestra/meltano_lightdash_bigquery.yml
@@ -12,7 +12,7 @@ pipeline:
           build_command: pip install -r requirements.txt && meltano install
           set_outputs: false
           source: GIT
-          command: meltano run tap-lightdash target-bigquery
+          command: python -m meltano.cli run tap-lightdash target-bigquery
           project_dir: python/meltano
           shallow_clone_dirs: python/meltano
         depends_on: []


### PR DESCRIPTION
## Follow-up to #251

`meltano run tap-lightdash target-bigquery` on its own doesn't satisfy
Orchestra's `PYTHON_EXECUTE_SCRIPT` command validation, which requires
the command to start with `python`/`poetry`/`uv` — that's why #251's
fix broke pipeline validation (`Invalid parameters for
PYTHON_EXECUTE_SCRIPT ... command`).

`meltano`'s console-script entry point is `meltano.cli:main`, so
`python -m meltano.cli run ...` satisfies the schema and actually
invokes the CLI correctly (unlike `python -m meltano`, which fails
because the package has no `__main__.py`).

Verified locally:
```
$ python -m meltano.cli --version
meltano, version 4.2.2
$ python -m meltano.cli run --help
Usage: python -m meltano.cli run [OPTIONS] [BLOCKS]...
```
Also re-validated the full pipeline YAML against Orchestra's schema
via `validate_pipeline` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)