### PR TITLE
Switch tap-lightdash extractor back to upstream repo

### DIFF
--- a/python/meltano/meltano.yml
+++ b/python/meltano/meltano.yml
@@ -7,7 +7,7 @@ plugins:
   extractors:
     - name: tap-lightdash
       variant: gthesheep
-      pip_url: git+https://github.com/gthesheep-orchestra/tap-lightdash.git
+      pip_url: git+https://github.com/gthesheep/tap-lightdash.git
       config:
         url: $TAP_LIGHTDASH_URL
         personal_access_token: $TAP_LIGHTDASH_PERSONAL_ACCESS_TOKEN


### PR DESCRIPTION
The singer-sdk/pendulum build fix from [gthesheep-orchestra/tap-lightdash#1](https://github.com/gthesheep-orchestra/tap-lightdash/pull/1)
is now merged upstream into `gthesheep/tap-lightdash` main, so point the
meltano project back at the original repo instead of the fork used for
testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)